### PR TITLE
feat(admin-schedule-day-calendar): major UI/UX update and selection 

### DIFF
--- a/src/components/admin-schedule/DayCalendar/availability-layer.tsx
+++ b/src/components/admin-schedule/DayCalendar/availability-layer.tsx
@@ -1,0 +1,253 @@
+import * as React from 'react';
+import { useMemo } from 'react';
+import { TimeSlot } from './admin-calendar-day';
+import { useStudent } from '@/hooks/useStudentQuery';
+import { useTeacher } from '@/hooks/useTeacherQuery';
+
+interface AvailabilityLayerProps {
+  timeSlots: TimeSlot[];
+  booths: { boothId: string; name: string }[];
+  teacherAvailability?: boolean[]; // Массив доступности для слотов времени
+  studentAvailability?: boolean[]; // Массив доступности для слотов времени
+  timeSlotHeight: number;
+}
+
+// Цветовая схема
+const AVAILABILITY_COLORS = {
+  teacher: 'rgba(34, 197, 94, 0.2)',     // Зеленый 20%
+  student: 'rgba(251, 191, 36, 0.2)',    // Янтарный 20%
+  both: 'rgba(59, 130, 246, 0.4)',       // Синий 40% (заметное пересечение)
+  // Темная тема
+  teacherDark: 'rgba(34, 197, 94, 0.15)',
+  studentDark: 'rgba(251, 191, 36, 0.15)',
+  bothDark: 'rgba(59, 130, 246, 0.3)',
+};
+
+export const AvailabilityLayer: React.FC<AvailabilityLayerProps> = ({
+  timeSlots,
+  booths,
+  teacherAvailability,
+  studentAvailability,
+  timeSlotHeight,
+}) => {
+  // Добавим отладку с идентификацией
+
+
+  const availabilityBlocks = useMemo(() => {
+    const blocks: React.JSX.Element[] = [];
+    
+    if (!teacherAvailability && !studentAvailability) {
+      return blocks;
+    }
+
+    // Для каждого временного слота создаем блок в строке заголовка времени
+    timeSlots.forEach((slot, slotIndex) => {
+      const hasTeacher = teacherAvailability?.[slotIndex] || false;
+      const hasStudent = studentAvailability?.[slotIndex] || false;
+      
+      if (!hasTeacher && !hasStudent) return;
+
+      // Определяем цвет на основе доступности
+      let backgroundColor: string;
+      if (hasTeacher && hasStudent) {
+        backgroundColor = AVAILABILITY_COLORS.both;
+      } else if (hasTeacher) {
+        backgroundColor = AVAILABILITY_COLORS.teacher;
+      } else {
+        backgroundColor = AVAILABILITY_COLORS.student;
+      }
+
+      // Создаем блок только в строке заголовка (где показано время)
+      const key = `availability-header-${slotIndex}`;
+      const left = slotIndex * 40; // Позиция по горизонтали
+      const top = 0; // В самом верху контейнера
+      
+      blocks.push(
+        <div
+          key={key}
+          className="absolute pointer-events-none"
+          style={{
+            left: `${left}px`,
+            top: `${top}px`,
+            width: '40px',
+            height: `${timeSlotHeight}px`,
+            backgroundColor,
+            zIndex: 1,
+          }}
+        />
+      );
+    });
+
+    return blocks;
+  }, [timeSlots, teacherAvailability, studentAvailability, timeSlotHeight]);
+
+  return (
+    <div className="absolute inset-0 pointer-events-none">
+      {availabilityBlocks}
+    </div>
+  );
+};
+
+// Вспомогательная функция для конвертации доступности в массив boolean для слотов
+export function convertAvailabilityToSlots(
+  availability: {
+    timeSlots: {
+      startTime: string;
+      endTime: string;
+    }[];
+    fullDay: boolean;
+  } | null,
+  timeSlots: TimeSlot[]
+): boolean[] {
+  const result = new Array(timeSlots.length).fill(false);
+  
+  if (!availability) return result;
+  
+  if (availability.fullDay) {
+    // Если полный день - все слоты доступны
+    return new Array(timeSlots.length).fill(true);
+  }
+  
+  // Для каждого доступного временного промежутка
+  availability.timeSlots.forEach(({ startTime, endTime }) => {
+    // Находим индексы начала и конца
+    const startIndex = timeSlots.findIndex(slot => slot.start === startTime);
+    let endIndex = timeSlots.findIndex(slot => slot.start === endTime);
+    
+    // Если не нашли точное совпадение для конца, ищем слот, который заканчивается в это время
+    if (endIndex === -1) {
+      endIndex = timeSlots.findIndex(slot => slot.end === endTime);
+      if (endIndex !== -1) {
+        endIndex++; // Включаем этот слот тоже
+      }
+    }
+    
+    if (startIndex !== -1) {
+      // Если endIndex не найден, заполняем до конца дня или до последнего слота
+      const end = endIndex !== -1 ? endIndex : timeSlots.length;
+      
+      // Помечаем слоты как доступные
+      for (let i = startIndex; i < end; i++) {
+        if (i < result.length) {
+          result[i] = true;
+        }
+      }
+    }
+  });
+  
+  console.log('Converted availability:', {
+    availableSlots: result.filter(x => x).length,
+    totalSlots: result.length,
+    indices: result.map((available, idx) => available ? idx : -1).filter(x => x >= 0)
+  });
+  
+  return result;
+}
+
+// Тип для API ответа доступности
+export interface AvailabilityResponse {
+  regularAvailability: {
+    dayOfWeek: string;
+    timeSlots: {
+      id: string;
+      startTime: string;
+      endTime: string;
+    }[];
+    fullDay: boolean;
+  }[];
+  exceptionalAvailability: {
+    date: string;
+    timeSlots: {
+      id: string;
+      startTime: string;
+      endTime: string;
+    }[];
+    fullDay: boolean;
+    reason?: string | null;
+    notes?: string | null;
+  }[];
+}
+
+// Функция для получения доступности на конкретную дату
+export function getAvailabilityForDate(
+  date: Date,
+  availability: AvailabilityResponse
+): {
+  timeSlots: { startTime: string; endTime: string }[];
+  fullDay: boolean;
+} | null {
+  const dateStr = date.toISOString().split('T')[0];
+  const dayOfWeek = date.getDay();
+  
+  // Сначала проверяем исключительную доступность
+  const exceptional = availability.exceptionalAvailability.find(
+    exc => exc.date === dateStr
+  );
+  
+  if (exceptional) {
+    return {
+      timeSlots: exceptional.timeSlots,
+      fullDay: exceptional.fullDay
+    };
+  }
+  
+  // Затем проверяем регулярную доступность
+  // Конвертируем день недели в строку (MONDAY, TUESDAY, etc.)
+  const dayNames = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
+  const dayName = dayNames[dayOfWeek];
+  
+  const regular = availability.regularAvailability.find(
+    reg => reg.dayOfWeek === dayName || reg.dayOfWeek === dayOfWeek.toString()
+  );
+  
+  if (regular) {
+    return {
+      timeSlots: regular.timeSlots,
+      fullDay: regular.fullDay
+    };
+  }
+  
+  return null;
+}
+
+// Hook для получения доступности учителя и студента
+export function useAvailability(
+  teacherId: string | undefined,
+  studentId: string | undefined,
+  date: Date,
+  timeSlots: TimeSlot[]
+) {
+  const { data: teacher } = useTeacher(teacherId || '');
+  const { data: student } = useStudent(studentId || '');
+  
+  const teacherAvailability = useMemo(() => {
+    if (!teacher || !teacherId) return undefined;
+    
+    const availability = getAvailabilityForDate(date, {
+      regularAvailability: teacher.regularAvailability || [],
+      exceptionalAvailability: teacher.exceptionalAvailability || []
+    });
+    
+    console.log(`Teacher availability for ${date.toISOString().split('T')[0]}:`, availability);
+    
+    return convertAvailabilityToSlots(availability, timeSlots);
+  }, [teacher, teacherId, date, timeSlots]);
+  
+  const studentAvailability = useMemo(() => {
+    if (!student || !studentId) return undefined;
+    
+    const availability = getAvailabilityForDate(date, {
+      regularAvailability: student.regularAvailability || [],
+      exceptionalAvailability: student.exceptionalAvailability || []
+    });
+    
+    console.log(`Student availability for ${date.toISOString().split('T')[0]}:`, availability);
+    
+    return convertAvailabilityToSlots(availability, timeSlots);
+  }, [student, studentId, date, timeSlots]);
+  
+  return {
+    teacherAvailability,
+    studentAvailability
+  };
+}

--- a/src/components/admin-schedule/DayCalendar/day-selector.tsx
+++ b/src/components/admin-schedule/DayCalendar/day-selector.tsx
@@ -1,109 +1,203 @@
-import React, { useMemo } from 'react';
+"use client"
+
+import type React from "react"
+import { useMemo, useState } from "react"
+import { format, addDays, isSameDay, startOfDay, addMonths } from "date-fns"
+import { ja } from "date-fns/locale"
+import { Calendar } from "@/components/ui/calendar"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Button } from "@/components/ui/button"
+import { CalendarIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
 
 type DaySelectorProps = {
-  selectedDays: Date[];
-  onSelectDay: (date: Date, isSelected: boolean) => void;
-};
-
-const isSameDayDate = (date1: Date, date2: Date): boolean => {
-  return (
-    date1.getDate() === date2.getDate() &&
-    date1.getMonth() === date2.getMonth() &&
-    date1.getFullYear() === date2.getFullYear()
-  );
-};
+  startDate: Date
+  selectedDays: Date[]
+  onSelectDay: (date: Date, isSelected: boolean) => void
+  onStartDateChange: (date: Date) => void
+}
 
 const getDateKey = (date: Date): string => {
-  return date.toISOString().split('T')[0];
-};
+  return date.toISOString().split("T")[0]
+}
 
-export const DaySelector: React.FC<DaySelectorProps> = ({ selectedDays, onSelectDay }) => {
+// Японские сокращения дней недели
+const japaneseWeekdays = ["日", "月", "火", "水", "木", "金", "土"]
+
+export const DaySelector: React.FC<DaySelectorProps> = ({
+  startDate,
+  selectedDays,
+  onSelectDay,
+  onStartDateChange,
+}) => {
+  const [calendarOpen, setCalendarOpen] = useState(false)
+
   const today = useMemo(() => {
-    const date = new Date();
-    date.setHours(12, 0, 0, 0);
-    return date;
-  }, []);
-  
-  const currentDayOfWeek = today.getDay();
-  
-  const upcomingDates = useMemo(() => {
-    const dates: Date[] = [];
-    
-    for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek++) {
-      const date = new Date(today);
-      
-      if (dayOfWeek === currentDayOfWeek) {
-        dates.push(date);
-        continue;
-      }
-      
-      let daysToAdd;
-      if (dayOfWeek > currentDayOfWeek) {
-        daysToAdd = dayOfWeek - currentDayOfWeek;
-      } else {
-        daysToAdd = 7 - (currentDayOfWeek - dayOfWeek);
-      }
-      
-      date.setDate(today.getDate() + daysToAdd);
-      date.setHours(12, 0, 0, 0);
-      dates.push(date);
+    const date = new Date()
+    return startOfDay(date)
+  }, [])
+
+  const maxDate = useMemo(() => {
+    return addMonths(today, 3)
+  }, [today])
+
+  const displayDays = useMemo(() => {
+    const days: Date[] = []
+    for (let i = 0; i < 7; i++) {
+      days.push(addDays(startDate, i))
     }
-    
-    return dates;
-  }, [today, currentDayOfWeek]);
-  
-  const daysOfWeek = [
-    { label: '月', value: 1, index: 1 },
-    { label: '火', value: 2, index: 2 },
-    { label: '水', value: 3, index: 3 },
-    { label: '木', value: 4, index: 4 },
-    { label: '金', value: 5, index: 5 },
-    { label: '土', value: 6, index: 6 },
-    { label: '日', value: 0, index: 0 }
-  ];
-  
-  const isDaySelected = (dayValue: number) => {
-    const targetDate = upcomingDates[dayValue];
-    return selectedDays.some(date => isSameDayDate(date, targetDate));
-  };
-  
+    return days
+  }, [startDate])
+
+  const isDaySelected = (date: Date) => {
+    return selectedDays.some((selectedDate) => isSameDay(selectedDate, date))
+  }
+
+  const handleStartDateChange = (date: Date | undefined) => {
+    if (date) {
+      onStartDateChange(date)
+      setCalendarOpen(false)
+    }
+  }
+
+  const handleTodayClick = () => {
+    onStartDateChange(today)
+    setCalendarOpen(false)
+  }
+
+  const isViewingToday = isSameDay(startDate, today)
+
   return (
-    <div className="flex space-x-2 items-center">
-      <span className="text-sm font-medium text-foreground">表示する日:</span>
-      
-      {daysOfWeek.map(day => {
-        const isToday = day.value === currentDayOfWeek;
-        const isSelected = isDaySelected(day.value);
-        const targetDate = upcomingDates[day.value];
-        
-        return (
-          <label 
-            key={day.value}
-            className={`
-              inline-flex items-center justify-center w-8 h-8 rounded-full transition-colors
-              ${isSelected 
-                ? 'bg-primary text-primary-foreground ring-2 ring-primary' 
-                : isToday 
-                  ? 'bg-secondary text-secondary-foreground border border-input' 
-                  : 'bg-background text-foreground border border-input'
-              } 
-              ${isToday ? 'font-bold' : ''}
-              cursor-pointer hover:bg-accent hover:text-accent-foreground
-            `}
-            title={`${getDateKey(targetDate)}`}
-          >
-            <input
-              type="checkbox"
-              className="sr-only"
-              checked={isSelected}
-              onChange={(e) => {
-                onSelectDay(targetDate, e.target.checked);
+    <div className="flex items-center gap-4">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-foreground">表示期間:</span>
+
+        <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className={cn("h-8 px-3 text-xs font-normal", !startDate && "text-muted-foreground")}
+            >
+              <CalendarIcon className="mr-2 h-3 w-3" />
+              {format(startDate, "M月d日", { locale: ja })} - {format(addDays(startDate, 6), "M月d日", { locale: ja })}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="single"
+              selected={startDate}
+              onSelect={handleStartDateChange}
+              disabled={(date) => date < today || date > maxDate}
+              initialFocus
+              locale={ja}
+              modifiers={{
+                // Подсвечиваем весь 7-дневный диапазон
+                rangeStart: (date) => isSameDay(date, startDate),
+                rangeMiddle: (date) => {
+                  const daysDiff = Math.floor((date.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+                  return daysDiff > 0 && daysDiff < 6
+                },
+                rangeEnd: (date) => isSameDay(date, addDays(startDate, 6)),
+                // Выбранные дни в диапазоне
+                selectedInRange: (date) => {
+                  const daysDiff = Math.floor((date.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+                  const isInRange = daysDiff >= 0 && daysDiff <= 6
+                  return isInRange && isDaySelected(date)
+                },
+              }}
+              modifiersStyles={{
+                rangeStart: {
+                  backgroundColor: "hsl(var(--primary))",
+                  color: "hsl(var(--primary-foreground))",
+                  borderRadius: "6px 0 0 6px",
+                  fontWeight: "bold",
+                },
+                rangeMiddle: {
+                  backgroundColor: "hsl(var(--primary) / 0.1)",
+                  color: "hsl(var(--foreground))",
+                  borderRadius: "0",
+                },
+                rangeEnd: {
+                  backgroundColor: "hsl(var(--primary) / 0.3)",
+                  color: "hsl(var(--foreground))",
+                  borderRadius: "0 6px 6px 0",
+                  border: "1px solid hsl(var(--primary) / 0.5)",
+                },
+                selectedInRange: {
+                  backgroundColor: "hsl(var(--primary))",
+                  color: "hsl(var(--primary-foreground))",
+                  fontWeight: "bold",
+                  border: "2px solid hsl(var(--primary))",
+                },
               }}
             />
-            {day.label}
-          </label>
-        );
-      })}
+            <div className="p-3 border-t">
+              <Button
+                size="sm"
+                variant="outline"
+                className="w-full"
+                onClick={handleTodayClick}
+                disabled={isViewingToday}
+              >
+                今日
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
+
+        {!isViewingToday && (
+          <Button size="sm" variant="ghost" className="h-8 px-2 text-xs" onClick={handleTodayClick}>
+            今日に戻る
+          </Button>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-foreground">選択日:</span>
+
+        <div className="flex space-x-1">
+          {displayDays.map((date, index) => {
+            const isToday = isSameDay(date, today)
+            const isSelected = isDaySelected(date)
+            const dayNumber = date.getDate()
+            const monthName = format(date, "M月", { locale: ja })
+            const dayOfWeek = japaneseWeekdays[date.getDay()]
+
+            return (
+              <label
+                key={getDateKey(date)}
+                className={cn(
+                  "relative inline-flex flex-col items-center justify-center w-12 h-12 rounded-lg transition-colors cursor-pointer",
+                  // Ховер только для невыбранных дней
+                  !isSelected && "hover:bg-accent hover:text-accent-foreground",
+                  // Выбранные дни - более насыщенный ховер
+                  isSelected && "bg-primary text-primary-foreground ring-2 ring-primary hover:bg-primary/90",
+                  !isSelected && isToday && "bg-yellow-50 text-yellow-800 border border-yellow-200",
+                  !isSelected && !isToday && "bg-background text-foreground border border-input",
+                )}
+                title={format(date, "yyyy年M月d日（E）", { locale: ja })}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={isSelected}
+                  onChange={(e) => onSelectDay(date, e.target.checked)}
+                />
+                <span className="text-sm font-medium leading-none">{dayNumber}</span>
+                <span className="text-[10px] text-muted-foreground mt-0.5">{dayOfWeek}</span>
+
+                {/* Индикатор начала месяца */}
+                {date.getDate() === 1 && (
+                  <span className="absolute -top-1 -right-1 text-[8px] px-1 bg-muted text-muted-foreground rounded">
+                    {monthName}
+                  </span>
+                )}
+              </label>
+            )
+          })}
+        </div>
+      </div>
     </div>
-  );
-};
+  )
+}

--- a/src/components/admin-schedule/DayCalendar/lesson-card.tsx
+++ b/src/components/admin-schedule/DayCalendar/lesson-card.tsx
@@ -17,18 +17,15 @@ interface LessonCardProps {
   maxZIndex?: number;
 }
 
-// Улучшенная функция извлечения времени
 const extractTime = (timeValue: string | Date | undefined): string => {
   if (!timeValue) return '';
   
   try {
     if (typeof timeValue === 'string') {
-      // Если формат времени уже "HH:MM" (как в API)
       if (/^\d{2}:\d{2}$/.test(timeValue)) {
         return timeValue;
       }
       
-      // Для ISO формата
       const timeMatch = timeValue.match(/T(\d{2}:\d{2}):/);
       if (timeMatch && timeMatch[1]) {
         return timeMatch[1];
@@ -54,12 +51,10 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
   const startTime = useMemo(() => extractTime(lesson.startTime), [lesson.startTime]);
   const endTime = useMemo(() => extractTime(lesson.endTime), [lesson.endTime]);
   
-  // Находим ближайший временной слот для начала урока
   const startSlotIndex = useMemo(() => {
     const exactMatch = timeSlots.findIndex(slot => slot.start === startTime);
     if (exactMatch >= 0) return exactMatch;
     
-    // Если точного совпадения нет, ищем ближайший слот
     return timeSlots.findIndex(slot => {
       const slotTime = slot.start.split(':').map(Number);
       const startTimeArr = startTime.split(':').map(Number);
@@ -73,12 +68,10 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
     });
   }, [startTime, timeSlots]);
   
-  // Находим ближайший временной слот для окончания урока
   const endSlotIndex = useMemo(() => {
     const exactMatch = timeSlots.findIndex(slot => slot.start === endTime);
     if (exactMatch >= 0) return exactMatch;
     
-    // Если точного совпадения нет, ищем ближайший слот
     const matchedIndex = timeSlots.findIndex(slot => {
       const slotTime = slot.start.split(':').map(Number);
       const endTimeArr = endTime.split(':').map(Number);
@@ -91,22 +84,19 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
       return slotMinutes <= endMinutes && endMinutes < (slotMinutes + 30);
     });
     
-    return matchedIndex >= 0 ? matchedIndex : startSlotIndex + 3; // Если не нашли, берем +3 слота от начала (1.5 часа)
+    return matchedIndex >= 0 ? matchedIndex : startSlotIndex + 3;
   }, [endTime, timeSlots, startSlotIndex]);
   
-  // Находим индекс кабинета
   const boothIndex = useMemo(() => {
-    // Точное совпадение по boothId
     const exactMatch = booths.findIndex(booth => booth.boothId === lesson.boothId);
     if (exactMatch >= 0) return exactMatch;
     
-    // Если не нашли, проверяем по имени кабинета
     const nameMatch = booths.findIndex(booth => 
       booth.name === lesson.boothName || 
       (typeof lesson.booth === 'object' && lesson.booth && booth.name === lesson.booth.name)
     );
     
-    return nameMatch >= 0 ? nameMatch : 0; // Если ни одно не совпало, используем первый кабинет
+    return nameMatch >= 0 ? nameMatch : 0;
   }, [booths, lesson.boothId, lesson.boothName, lesson.booth]);
   
   const isValidPosition = startSlotIndex >= 0 && endSlotIndex > startSlotIndex && boothIndex >= 0;
@@ -128,9 +118,8 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
       boothIndex 
     });
     
-    // Расчет продолжительности урока в минутах
     const calculateDurationInSlots = () => {
-      if (!startTime || !endTime) return 3; // По умолчанию 1.5 часа (3 слота по 30 минут)
+      if (!startTime || !endTime) return 3;
       
       const [startHour, startMin] = startTime.split(':').map(Number);
       const [endHour, endMin] = endTime.split(':').map(Number);
@@ -140,18 +129,14 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
       }
       
       const durationMinutes = ((endHour - startHour) * 60) + (endMin - startMin);
-      return Math.max(1, Math.ceil(durationMinutes / 30)); // Предполагаем, что один слот = 30 минут
+      return Math.max(1, Math.ceil(durationMinutes / 30));
     };
     
-    // Вычисляем примерную продолжительность урока
     const durationSlots = calculateDurationInSlots();
     
-    // Если не удалось определить позицию, но у нас есть время начала
-    // Пытаемся определить ближайший слот
     if (startTime) {
       const [hour, minute] = startTime.split(':').map(Number);
       if (!isNaN(hour) && !isNaN(minute)) {
-        // Ищем ближайший слот по времени
         const totalMinutes = hour * 60 + minute;
         let closestSlotIndex = -1;
         let minDiff = Infinity;
@@ -177,23 +162,22 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
       }
     }
     
-    // Если все методы не сработали, используем начало дня и стандартную продолжительность
     return {
-      effectiveStartIndex: 0, // Начало дня
+      effectiveStartIndex: 0,
       effectiveDuration: durationSlots
     };
   }, [isValidPosition, startSlotIndex, endSlotIndex, startTime, endTime, timeSlots, lesson.classId, boothIndex, lesson.boothId]);
   
   const colors = useMemo(() => {
-    // Определяем, является ли урок повторяющимся на основе наличия seriesId
     const isRecurringLesson = lesson.seriesId !== null && lesson.seriesId !== undefined;
+    const subjectName = lesson.subject?.name || lesson.subjectName || '';
     
     if (isRecurringLesson) {
       return {
-        background: 'bg-blue-100 dark:bg-blue-900/70',
-        border: 'border-blue-300 dark:border-blue-700',
-        text: 'text-blue-800 dark:text-blue-100',
-        hover: 'hover:bg-blue-200 dark:hover:bg-blue-800'
+        background: 'bg-indigo-100 dark:bg-indigo-900/70',
+        border: 'border-indigo-300 dark:border-indigo-700',
+        text: 'text-indigo-800 dark:text-indigo-100',
+        hover: 'hover:bg-indigo-200 dark:hover:bg-indigo-800'
       };
     } else {
       return {
@@ -203,13 +187,12 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
         hover: 'hover:bg-red-200 dark:hover:bg-red-800'
       };
     }
-  }, [lesson.seriesId]);
+  }, [lesson.seriesId, lesson.subject?.name, lesson.subjectName]);
   
-  // Рассчитываем CSS стиль
   const style = useMemo(() => ({
     position: 'absolute',
     left: `${effectiveStartIndex * 40 + 100}px`,
-    top: `${(boothIndex + 1) * timeSlotHeight}px`,
+    top: `${boothIndex * timeSlotHeight}px`, 
     width: `${effectiveDuration * 40}px`,
     height: `${timeSlotHeight - 2}px`,
     zIndex: maxZIndex - 1
@@ -217,13 +200,11 @@ const LessonCardComponent: React.FC<LessonCardProps> = ({
   
   const isNarrow = effectiveDuration <= 1;
   
-  // Защита от рендеринга вне видимой области
   if (effectiveStartIndex < 0) {
     console.error('Невозможно отобразить урок - недопустимый индекс начала:', effectiveStartIndex);
     return null;
   }
 
-  // Используем данные как из вложенных объектов, так и из плоских свойств (как в API)
   const subjectName = lesson.subject?.name || lesson.subjectName || 'Предмет не указан';
   const teacherName = lesson.teacher?.name || lesson.teacherName || 'Преподаватель не указан';
   const studentName = lesson.student?.name || lesson.studentName || 'Студент не указан';

--- a/src/components/admin-schedule/DayCalendar/lesson-dialog.tsx
+++ b/src/components/admin-schedule/DayCalendar/lesson-dialog.tsx
@@ -384,7 +384,7 @@ export const LessonDialog: React.FC<LessonDialogProps> = ({
           <DialogHeader>
             <DialogTitle>
               {mode === 'view' ? '授業の詳細' : '授業の編集'}
-              <span className={`text-sm font-normal ml-2 ${isRecurringLesson ? 'text-blue-500 dark:text-blue-400' : 'text-red-500 dark:text-red-400'}`}>
+              <span className={`text-sm font-normal ml-2 ${isRecurringLesson ? 'text-indigo-500 dark:text-indigo-400' : 'text-red-500 dark:text-red-400'}`}>
                 ({lesson.classType?.name || lesson.classTypeName || '不明'})
               </span>
             </DialogTitle>

--- a/src/hooks/useTeacherQuery.ts
+++ b/src/hooks/useTeacherQuery.ts
@@ -22,6 +22,26 @@ export type Teacher = {
     subjectId: string;
     subjectTypeIds: string[];
   }[];
+  regularAvailability: {
+    dayOfWeek: string;
+    timeSlots: {
+      id: string;
+      startTime: string;
+      endTime: string;
+    }[];
+    fullDay: boolean;
+  }[];
+  exceptionalAvailability: {
+    date: string;
+    timeSlots: {
+      id: string;
+      startTime: string;
+      endTime: string;
+    }[];
+    fullDay: boolean;
+    reason?: string | null;
+    notes?: string | null;
+  }[];
   createdAt: Date;
   updatedAt: Date;
   _optimistic?: boolean;


### PR DESCRIPTION
logic improvements

- Added selection options for lesson type, teacher, and student above the schedule
- Displayed student's and teacher's available time slots with intersection highlights
- Reworked lesson creation dialog with improved UX
- Disabled the create lesson button until a time range is selected for recurring lessons
- Removed cascading dropdown behavior
- Removed student type selection
- Enabled independent teacher and student selection (previous selections remain as default)

- Reworked day selector:
  - Now shows exact date and day of the week (e.g., June 5, Thursday) instead of weekday-only

- Disabled drag-to-create functionality until lesson type, teacher, and student are selected