### PR TITLE
feat: auto-scroll DayCalendar to earliest lesson on load

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "Bash(bun prisma db seed:*)",
       "Bash(cp:*)",
       "Bash(git pull:*)",
-      "Bash(bun prisma db pull:*)"
+      "Bash(bun prisma db pull:*)",
+      "Bash(git stash show:*)"
     ],
     "deny": []
   }

--- a/src/components/admin-schedule/DayCalendar/availability-layer.tsx
+++ b/src/components/admin-schedule/DayCalendar/availability-layer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMemo } from 'react';
-import { TimeSlot } from './admin-calendar-day';
+import { TimeSlot } from './day-calendar';
 import { useStudent } from '@/hooks/useStudentQuery';
 import { useTeacher } from '@/hooks/useTeacherQuery';
 

--- a/src/components/admin-schedule/DayCalendar/lesson-card.tsx
+++ b/src/components/admin-schedule/DayCalendar/lesson-card.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { ExtendedClassSessionWithRelations } from '@/hooks/useClassSessionQuery';
-import { TimeSlot } from './admin-calendar-day';
+import { TimeSlot } from './day-calendar';
 import { UserCheck, GraduationCap } from "lucide-react"
 
 interface Booth {
@@ -17,7 +17,7 @@ interface LessonCardProps {
   maxZIndex?: number;
 }
 
-const extractTime = (timeValue: string | Date | undefined): string => {
+export const extractTime = (timeValue: string | Date | undefined): string => {
   if (!timeValue) return '';
   
   try {


### PR DESCRIPTION
This PR implements auto-scrolling functionality for the DayCalendar component to automatically scroll to the earliest lesson when the component loads, improving user experience by showing the most relevant content first.