### PR TITLE
main: add local edge-cases pack (one-shot runner + JSON summary)

### DIFF
--- a/docs/class-series-generation.md
+++ b/docs/class-series-generation.md
@@ -1,0 +1,56 @@
+# Class Series Generation
+
+This document explains configuration precedence, the advance generation cron, and manual testing steps.
+
+## Configuration Precedence
+
+Effective scheduling configuration is resolved in this order:
+
+1. Per-Series Override (stored on `class_series.scheduling_override`)
+2. Branch-Specific Override (`branch_scheduling_config`)
+3. Global Base (`scheduling_config`)
+
+Notes:
+- `generationMonths` determines the advance lead window (months × 30 days) used by the cron.
+- Conflict flags (e.g., `markTeacherConflict`, `allowOutsideAvailabilityTeacher`) apply to on-demand extension and any place where conflict policy is evaluated.
+
+## Cron Schedule
+
+- Vercel cron invokes `GET /api/class-series/advance/cron` (see `vercel.json`).
+- Authorization: either `User-Agent: vercel-cron/1.0` or `Authorization: Bearer $CRON_SECRET` (recommended for production).
+- Production safeguard: set `ENABLE_SERIES_GENERATION=true` to allow cron execution in production. Otherwise the endpoint returns 403.
+- Query parameters:
+  - `leadDays` (optional): override calculated lead days for all processed series.
+  - `limit` (optional): limit number of series processed this run.
+  - `branchId` (optional): process only a single branch.
+  - `seriesId` (optional): process only a single series.
+
+## Idempotency
+
+Generation is idempotent. Before inserting, the system checks for an existing session with the same `seriesId`, `date`, `startTime`, and `endTime`. If found, it skips creation. Re-running cron or extend will not create duplicates.
+
+Resume semantics: if any insert fails, `last_generated_through` is advanced only to the last successfully created date. Re-running will safely fill gaps while skipping already-created sessions.
+
+## Cleanup Behavior
+
+When the last generated date reaches or exceeds a series `endDate`, the blueprint (`class_series`) is deleted automatically. Existing `class_sessions` are preserved.
+
+## Manual Test Steps
+
+1. Seed the database: `bun tsx prisma/seed.ts` (requires local Postgres and `DATABASE_URL`).
+2. Verify seeds via psql:
+   - `PGPASSWORD=postgres psql -h localhost -U postgres -d schedulewebsite -c "SELECT count(*) FROM class_series;"`
+   - `PGPASSWORD=postgres psql -h localhost -U postgres -d schedulewebsite -c "SELECT * FROM scheduling_config;"`
+3. Extend a series manually:
+   - `curl -X POST http://localhost:3000/api/class-series/<seriesId>/extend -H "Authorization: Bearer $CRON_SECRET" -d '{"months":1}'`
+4. Run advance cron locally:
+   - `curl -X GET "http://localhost:3000/api/class-series/advance/cron?limit=5" -H "Authorization: Bearer $CRON_SECRET"`
+5. Re-run the same command to confirm idempotency (no new sessions created).
+
+### Timezone/DST
+- Optional per-series `timezone` (e.g., `America/New_York`) ensures local time-of-day remains stable across DST transitions. Stored session timestamps are UTC; display converts using the series timezone.
+
+## Observability
+
+- API responses include counts of created/skip/conflict items.
+- Server logs include start/end markers and failures. Use platform logs to trace runs.

--- a/prisma/migrations/20250923170000_add_series_scheduling_override/migration.sql
+++ b/prisma/migrations/20250923170000_add_series_scheduling_override/migration.sql
@@ -1,0 +1,3 @@
+-- Add per-series scheduling override JSON column
+ALTER TABLE "class_series" ADD COLUMN IF NOT EXISTS "scheduling_override" JSONB;
+

--- a/prisma/migrations/20250923173000_add_class_series_timezone/migration.sql
+++ b/prisma/migrations/20250923173000_add_class_series_timezone/migration.sql
@@ -1,0 +1,3 @@
+-- Add timezone column for DST-aware generation
+ALTER TABLE "class_series" ADD COLUMN IF NOT EXISTS "timezone" VARCHAR(64);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,7 +22,10 @@ model ClassSeries {
   // Lifecycle & automation
   status               String    @default("ACTIVE")
   lastGeneratedThrough DateTime? @map("last_generated_through") @db.Date
+  timezone             String?   @map("timezone") @db.VarChar(64)
   notes                String?   @db.VarChar(255)
+  // Optional per-series scheduling override (takes precedence over branch/global)
+  schedulingOverride   Json?     @map("scheduling_override")
   createdAt            DateTime  @default(now()) @map("created_at") @db.Timestamp(6)
   updatedAt            DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamp(6)
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -91,6 +91,33 @@ async function main() {
     },
   });
 
+  // 1‑a-2. Scheduling configuration (GLOBAL + per-branch overrides)
+  await prisma.schedulingConfig.upsert({
+    where: { configId: "GLOBAL" },
+    update: {},
+    create: {
+      configId: "GLOBAL",
+      markTeacherConflict: true,
+      markStudentConflict: true,
+      markBoothConflict: true,
+      markTeacherUnavailable: false,
+      markStudentUnavailable: false,
+      markTeacherWrongTime: false,
+      markStudentWrongTime: false,
+      markNoSharedAvailability: false,
+      allowOutsideAvailabilityTeacher: false,
+      allowOutsideAvailabilityStudent: false,
+      generationMonths: 1,
+    },
+  });
+
+  // East branch override: allow outside availability for teacher and generate 2 months ahead
+  await prisma.branchSchedulingConfig.upsert({
+    where: { branchId: eastBranch.branchId },
+    update: { allowOutsideAvailabilityTeacher: true, generationMonths: 2 },
+    create: { branchId: eastBranch.branchId, allowOutsideAvailabilityTeacher: true, generationMonths: 2 },
+  });
+
   // 1‑b. StudentType
   const generalStudentType = await prisma.studentType.create({
     data: {

--- a/specs/006-carefully-audit-the/plan.md
+++ b/specs/006-carefully-audit-the/plan.md
@@ -1,0 +1,212 @@
+
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+## Execution Flow (/plan command scope)
+```
+1. Load feature spec from Input path
+   → If not found: ERROR "No feature spec at {path}"
+2. Fill Technical Context (scan for NEEDS CLARIFICATION)
+   → Detect Project Type from context (web=frontend+backend, mobile=app+api)
+   → Set Structure Decision based on project type
+3. Fill the Constitution Check section based on the content of the constitution document.
+4. Evaluate Constitution Check section below
+   → If violations exist: Document in Complexity Tracking
+   → If no justification possible: ERROR "Simplify approach first"
+   → Update Progress Tracking: Initial Constitution Check
+5. Execute Phase 0 → research.md
+   → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
+6. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, `GEMINI.md` for Gemini CLI, `QWEN.md` for Qwen Code or `AGENTS.md` for opencode).
+7. Re-evaluate Constitution Check section
+   → If new violations: Refactor design, return to Phase 1
+   → Update Progress Tracking: Post-Design Constitution Check
+8. Plan Phase 2 → Describe task generation approach (DO NOT create tasks.md)
+9. STOP - Ready for /tasks command
+```
+
+**IMPORTANT**: The /plan command STOPS at step 7. Phases 2-4 are executed by other commands:
+- Phase 2: /tasks command creates tasks.md
+- Phase 3-4: Implementation execution (manual or via tools)
+
+## Summary
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [single/web/mobile - determines source structure]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+```
+specs/[###-feature]/
+├── plan.md              # This file (/plan command output)
+├── research.md          # Phase 0 output (/plan command)
+├── data-model.md        # Phase 1 output (/plan command)
+├── quickstart.md        # Phase 1 output (/plan command)
+├── contracts/           # Phase 1 output (/plan command)
+└── tasks.md             # Phase 2 output (/tasks command - NOT created by /plan)
+```
+
+### Source Code (repository root)
+```
+# Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure]
+```
+
+**Structure Decision**: [DEFAULT to Option 1 unless Technical Context indicates web/mobile app]
+
+## Phase 0: Outline & Research
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+   ```
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+## Phase 1: Design & Contracts
+*Prerequisites: research.md complete*
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Generate API contracts** from functional requirements:
+   - For each user action → endpoint
+   - Use standard REST/GraphQL patterns
+   - Output OpenAPI/GraphQL schema to `/contracts/`
+
+3. **Generate contract tests** from contracts:
+   - One test file per endpoint
+   - Assert request/response schemas
+   - Tests must fail (no implementation yet)
+
+4. **Extract test scenarios** from user stories:
+   - Each story → integration test scenario
+   - Quickstart test = story validation steps
+
+5. **Update agent file incrementally** (O(1) operation):
+   - Run `.specify/scripts/bash/update-agent-context.sh gemini`
+     **IMPORTANT**: Execute it exactly as specified above. Do not add or remove any arguments.
+   - If exists: Add only NEW tech from current plan
+   - Preserve manual additions between markers
+   - Update recent changes (keep last 3)
+   - Keep under 150 lines for token efficiency
+   - Output to repository root
+
+**Output**: data-model.md, /contracts/*, failing tests, quickstart.md, agent-specific file
+
+## Phase 2: Task Planning Approach
+*This section describes what the /tasks command will do - DO NOT execute during /plan*
+
+**Task Generation Strategy**:
+- Load `.specify/templates/tasks-template.md` as base
+- Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
+- Each contract → contract test task [P]
+- Each entity → model creation task [P] 
+- Each user story → integration test task
+- Implementation tasks to make tests pass
+
+**Ordering Strategy**:
+- TDD order: Tests before implementation 
+- Dependency order: Models before services before UI
+- Mark [P] for parallel execution (independent files)
+
+**Estimated Output**: 25-30 numbered, ordered tasks in tasks.md
+
+**IMPORTANT**: This phase is executed by the /tasks command, NOT by /plan
+
+## Phase 3+: Future Implementation
+*These phases are beyond the scope of the /plan command*
+
+**Phase 3**: Task execution (/tasks command creates tasks.md)  
+**Phase 4**: Implementation (execute tasks.md following constitutional principles)  
+**Phase 5**: Validation (run tests, execute quickstart.md, performance validation)
+
+## Complexity Tracking
+*Fill ONLY if Constitution Check has violations that must be justified*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+
+
+## Progress Tracking
+*This checklist is updated during execution flow*
+
+**Phase Status**:
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [ ] Phase 2: Task planning complete (/plan command - describe approach only)
+- [x] Phase 3: Tasks generated (/tasks command)
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [ ] All NEEDS CLARIFICATION resolved
+- [ ] Complexity deviations documented
+
+---
+*Based on Constitution v2.1.1 - See `/memory/constitution.md`*

--- a/specs/006-carefully-audit-the/research.md
+++ b/specs/006-carefully-audit-the/research.md
@@ -1,0 +1,49 @@
+# Research & Audit Notes — Class Series Generation
+
+Date: 2025-09-23
+
+## Current Implementation Map
+
+- Schema
+  - `class_series` (blueprint) exists (Prisma `ClassSeries`).
+  - Added `scheduling_override` JSONB (per-series overrides, this change).
+  - Global: `scheduling_config`; Branch override: `branch_scheduling_config`.
+  - `class_sessions` holds generated instances.
+
+- Generation Paths
+  - On-demand extension: `src/app/api/class-series/[seriesId]/extend/route.ts`.
+    - Computes candidate dates from `lastGeneratedThrough`/`startDate` to `months` ahead.
+    - Uses centralized config and availability checks to mark conflicts.
+    - Now merges per-series overrides and adds idempotency and advisory locks.
+  - Scheduled advance (cron): `src/app/api/class-series/advance/cron/route.ts`.
+    - Uses `src/lib/series-advance.ts` helpers.
+    - Lead window = `generationMonths * 30` days (now honors per-series overrides).
+    - Creates sessions with time/vacation conflict marking.
+    - Now idempotent and guarded by advisory locks.
+
+- Config Resolution
+  - `src/lib/scheduling-config.ts`: resolves Global → Branch; new `applySeriesOverride()` overlays per-series JSON.
+
+- Safeguards & Auth
+  - Cron requires `CRON_SECRET` or vercel-cron UA; permissive in dev.
+  - Branch scoping enforced for non-admins.
+
+## Gaps vs. Spec (before changes)
+
+- FR-001 (precedence): No per-series override → added `scheduling_override` + merge.
+- FR-002 (idempotency): Re-runs could duplicate → added duplicate check on create.
+- FR-010 (resume): Depended on `lastGeneratedThrough` only → idempotency ensures safe resume; could be incrementally updated in future for finer granularity.
+- FR-011 (concurrency): No lock → added advisory locks per series.
+
+## Open Questions / Assumptions
+
+- Conflicting rules reporting (spec NEEDS CLARIFICATION): for now, log conflict reasons in API responses; consider admin notifications later.
+- Timezone/DST: Dates/times are UTC with local presentation; if future TZ variability is needed, add `timezone` on series.
+
+## Manual Validation Plan
+
+1) Seed DB (global + east branch overrides + demo series).  
+2) Run extend and cron twice; verify idempotency (same counts, no new rows).  
+3) Set a series `endDate` in the past and extend; confirm blueprint deletion and sessions untouched.  
+4) Toggle branch override (`generationMonths`) to 2 and ensure cron target window increases.
+

--- a/specs/006-carefully-audit-the/spec.md
+++ b/specs/006-carefully-audit-the/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: Audit and Refine Class Series Generation
+
+**Feature Branch**: `006-carefully-audit-the`  
+**Created**: 2025-09-23  
+**Status**: Draft  
+**Input**: User description: "Carefully audit the class series generation implementation end-to-end. Confirm that class sessions are generated from class series according to rules defined in the separate rules model, and that configuration resolution correctly derives from base configs, applies global branch-specific overrides, and supports per-series overrides with predictable precedence. Trace the flow step by step to identify any issues, bugs, or edge cases, including idempotency on repeated runs, timezone handling, daylight saving, boundaries at start/end dates, and partial updates. Manually test the full flow: simulate cron job executions locally, verify that sessions are created exactly as expected in the local database (counts, dates, times, instructors/rooms if applicable), and ensure deletions/cleanup occur when series reach their end time, with no orphaned or duplicate records. Validate that reruns produce consistent results, logs are clear and actionable, failures are retried or surfaced, and feature flags or environment guards prevent unintended production changes. Provide concrete fixes with minimal code changes, add unit/integration tests for rule resolution and generation/deletion, document the precedence and cron schedule, and include before/after database snapshots and test steps to reproduce."
+
+---
+## Clarifications
+
+### Session 2025-09-23
+- Q: When a generation or cleanup job is interrupted and restarted, how should it handle sessions from the failed run? → A: Identify the last successfully completed step and resume from that point.
+- Q: What should happen if a class series is updated while a generation job for that same series is already in progress? → A: The running job should complete using the configuration from when it started.
+- Q: For observability, what key metric should be prioritized for the generation process? → A: All of the above.
+- Q: What is the maximum acceptable runtime for a single, typical class series generation job? → A: Under 30 minutes.
+- Q: To be clear, which of these is the correct behavior after a series' `endDate` is reached? → A: Delete the Class Series itself, but keep all its generated Class Sessions.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### Primary User Story
+As a System Administrator, I want to ensure the automated class session generation process is reliable, predictable, and robust, so that class schedules are always accurate and maintainable without manual intervention.
+
+### Acceptance Scenarios
+1.  **Given** a base scheduling configuration and a branch-specific override, **When** the generation process runs for a class series without its own override, **Then** the branch-specific override MUST be applied.
+2.  **Given** a class series with a specific scheduling rule override, **When** the generation process runs, **Then** the series-specific override MUST take precedence over all other configurations.
+3.  **Given** the generation process is executed multiple times for the same time period, **When** no underlying data has changed, **Then** the resulting class sessions in the database MUST remain identical (idempotency).
+4.  **Given** a class series that spans a daylight saving time transition, **When** sessions are generated, **Then** the session times MUST be correct according to the local timezone.
+5.  **Given** a class series reaches its `end` date, **When** the cleanup process runs, **Then** the class series itself MUST be deleted, leaving all its generated class sessions untouched.
+
+### Edge Cases
+- How does the system handle a run that is interrupted mid-way? → It should identify the last successfully completed step and resume from that point.
+- What happens if the database connection is lost during a generation or cleanup operation? → The job should fail and resume on the next run.
+- How are invalid or conflicting rules in the configuration resolved or reported? → [NEEDS CLARIFICATION: What is the desired reporting mechanism for conflicting rules? e.g., log error, admin notification]
+- What is the behavior when a class series is updated while a generation job for it is already running? → The running job should complete using the configuration from when it started.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+- **FR-001**: The system MUST correctly resolve scheduling configurations with a clear precedence order: Per-Series Override > Global Branch-Specific Override > Base Configuration.
+- **FR-002**: The class session generation process MUST be idempotent.
+- **FR-003**: The system MUST handle timezone conversions and daylight saving time changes accurately.
+- **FR-004**: The system MUST automatically delete a `Class Series` after its `endDate` is reached.
+- **FR-005**: The generation and cleanup processes MUST produce clear, actionable logs.
+- **FR-006**: The system MUST have safeguards (e.g., feature flags) to prevent unintended execution in the production environment.
+- **FR-007**: The system MUST include unit and/or integration tests for configuration resolution logic.
+- **FR-008**: The system MUST include unit and/or integration tests for the session generation and deletion logic.
+- **FR-009**: The configuration precedence, cron schedule, and manual testing procedures MUST be documented.
+- **FR-010**: Interrupted jobs MUST be able to resume from the last successfully completed step.
+- **FR-011**: A running generation job MUST NOT be affected by concurrent updates to its class series.
+- **FR-012**: The generation process MUST record metrics for job duration, number of sessions created/deleted, and number of errors.
+
+### Non-Functional Requirements
+- **NFR-001**: A typical class series generation job MUST complete in under 30 minutes.
+
+### Key Entities *(include if feature involves data)*
+- **Scheduling Configuration**: Rules defining when and how class sessions are generated. Includes base, branch-specific, and series-specific levels.
+- **Class Series**: A template for creating multiple `Class Sessions` over a period.
+- **Class Session**: An individual, scheduled class instance with a specific time, date, and resources.
+
+---
+
+## Review & Acceptance Checklist
+*GATE: Automated checks run during main() execution*
+
+### Content Quality
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+### Requirement Completeness
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous  
+- [ ] Success criteria are measurable
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+---
+
+## Execution Status
+*Updated by main() during processing*
+
+- [ ] User description parsed
+- [ ] Key concepts extracted
+- [ ] Ambiguities marked
+- [ ] User scenarios defined
+- [ ] Requirements generated
+- [ ] Entities identified
+- [ ] Review checklist passed
+
+---

--- a/specs/006-carefully-audit-the/tasks.md
+++ b/specs/006-carefully-audit-the/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Audit and Refine Class Series Generation
+
+**Input**: Design documents from `/specs/006-carefully-audit-the/`
+**Prerequisites**: spec.md
+
+## Execution Flow
+The process for this audit is as follows:
+1.  **Audit & Setup**: Understand the existing code and prepare the testing environment.
+2.  **Test Existing Behavior**: Write tests based on the `spec.md` acceptance criteria to validate the current implementation and identify bugs.
+3.  **Implement Fixes**: Address the issues discovered during testing.
+4.  **Integrate & Refine**: Improve logging, metrics, and error handling.
+5.  **Polish & Document**: Finalize documentation and performance tests.
+
+## Path Conventions
+- Source code: `src/`
+- Test code: `tests/`
+- Documentation: `docs/`
+
+---
+
+## Phase 3.1: Audit & Setup
+- [x] T001: **Initial Code Audit**. Search the codebase for "ClassSeries", "Scheduling Configuration", and "generation" to identify all relevant files (services, jobs, models) related to the class series generation process.
+- [x] T002: **Document Existing Flow**. Based on the audit, create a temporary document outlining the current step-by-step process of how class sessions are generated from series, including configuration resolution. (See `specs/006-carefully-audit-the/research.md`)
+- [x] T003: **Setup Local Test Environment**. Write a seed script in `prisma/seed.ts` to populate the local database with necessary data (base/branch/series configurations, users, class series) to manually trigger and test the generation process. (Global + East branch overrides seeded)
+
+## Phase 3.2: Tests First (Verify Existing Behavior)
+**CRITICAL: These tests target the existing implementation to expose bugs before fixing them.**
+- [ ] T004 [P]: **Integration Test for Config Precedence**. In `tests/integration/class-series-generation.test.ts`, write a test to verify that scheduling configurations are resolved in the correct order: Per-Series > Branch-Specific > Base (FR-001, Scenarios 1 & 2).
+- [ ] T005 [P]: **Integration Test for Idempotency**. In `tests/integration/class-series-generation.test.ts`, write a test to confirm that running the generation process multiple times produces an identical set of class sessions (FR-002, Scenario 3).
+- [ ] T006 [P]: **Integration Test for Timezone Handling**. In `tests/integration/class-series-generation.test.ts`, create a test for a class series that spans a Daylight Saving Time transition and assert that session times are correct (FR-003, Scenario 4).
+- [ ] T007 [P]: **Integration Test for Series Cleanup**. In `tests/integration/class-series-generation.test.ts`, write a test to ensure that a `ClassSeries` is deleted after its `endDate` is reached, while its sessions remain (FR-004, Scenario 5).
+- [ ] T008 [P]: **Integration Test for Interrupted Jobs**. In `tests/integration/class-series-generation.test.ts`, simulate a job interruption and verify that it can resume from the last completed step on the next run (FR-010).
+- [ ] T009 [P]: **Integration Test for Concurrency**. In `tests/integration/class-series-generation.test.ts`, write a test that updates a `ClassSeries` while a generation job for it is running and confirms the job completes with its initial configuration (FR-011).
+ - [x] T004 [P]: **Integration Test for Config Precedence** (added + passing).
+ - [x] T005 [P]: **Integration Test for Idempotency** (added + passing).
+ - [x] T006 [P]: **Integration Test for Timezone Handling** (added + passing). Implemented optional `timezone` on `class_series` and DST-aware generation.
+ - [x] T007 [P]: **Integration Test for Series Cleanup** (added + passing).
+ - [x] T008 [P]: **Integration Test for Interrupted Jobs** (added + passing). Implemented conservative advancement of `last_generated_through`.
+ - [x] T009 [P]: **Integration Test for Concurrency** (added + passing). Implemented advisory locks.
+
+## Phase 3.3: Core Implementation (Fixes)
+**ONLY begin after tests in Phase 3.2 are written and their results are known.**
+- [x] T010: **Fix Config Precedence**. Based on the results of T004, correct the configuration resolution logic. (Depends on T004)
+- [x] T011: **Fix Idempotency Issues**. Based on the results of T005, modify the generation logic to ensure it is fully idempotent. (Depends on T005)
+- [x] T012: **Fix Timezone/DST Bugs**. Implemented per-series timezone and DST-safe generation.
+- [x] T013: **Fix Series Cleanup Logic**. Confirmed deletion of blueprint at endDate boundary with sessions preserved.
+- [x] T014: **Implement Job Resumption**. Conservative advancement of lastGeneratedThrough + idempotent re-run.
+- [x] T015: **Implement Concurrency Control**. Based on the results of T009, add a locking mechanism or state check to prevent race conditions from concurrent updates. (Depends on T009)
+
+## Phase 3.4: Integration & Refinement
+- [ ] T016: **Audit and Improve Logging**. Review and enhance the logging throughout the generation and cleanup process to ensure logs are clear and actionable (FR-005).
+- [ ] T017: **Verify Environment Safeguards**. Check for existing feature flags or environment variables that prevent the process from running in production. Add them if they are missing (FR-006).
+- [ ] T018: **Audit and Improve Metrics**. Review and enhance the metrics collection for job duration, sessions created/deleted, and errors (FR-012).
+- [x] T019: **Implement Conflicting Rule Reporting**. Validation + best-effort system notification (`recipientType=SYSTEM`). Controlled by `ADMIN_NOTIFY_RECIPIENT` env; always logs.
+ - [x] T016: **Audit and Improve Logging**. Added structured summary log in cron endpoint.
+ - [x] T017: **Verify Environment Safeguards**. Added `ENABLE_SERIES_GENERATION` gate to cron in production.
+ - [x] T018: **Audit and Improve Metrics**. Added `durationMs` and aggregated counters in cron response; logs include summary.
+ - [ ] T019: **Implement Conflicting Rule Reporting**. Pending admin notification channel decision (currently structured responses + logs only).
+
+## Phase 3.5: Polish & Documentation
+- [ ] T020 [P]: **Performance Benchmark Test**. In `tests/performance/class-series-generation.test.ts`, create a test with a large and complex class series to benchmark the generation job's runtime and ensure it completes in under 30 minutes (NFR-001).
+- [x] T021 [P]: **Create Documentation**. Create a new file `docs/class-series-generation.md` and document the configuration precedence rules, the expected cron schedule, and the steps for manual testing (FR-009).
+- [ ] T022: **Final Code Review**. Perform a final review of all changes to ensure code quality, remove any temporary documentation or scripts, and confirm all tests are passing.
+
+## Dependencies
+- **Phase 3.1** must be completed before other phases.
+- **Phase 3.2** (tests) should be completed before **Phase 3.3** (fixes).
+- Tasks in **Phase 3.3** depend on the corresponding tests in **Phase 3.2**.
+
+## Parallel Example
+```
+# The following tests can be worked on in parallel:
+Task: "T004 [P]: Integration Test for Config Precedence"
+Task: "T005 [P]: Integration Test for Idempotency"
+Task: "T006 [P]: Integration Test for Timezone Handling"
+Task: "T007 [P]: Integration Test for Series Cleanup"
+Task: "T008 [P]: Integration Test for Interrupted Jobs"
+Task: "T009 [P]: Integration Test for Concurrency"
+
+# The following polish tasks can be worked on in parallel:
+Task: "T020 [P]: Performance Benchmark Test"
+Task: "T021 [P]: Create Documentation"
+```

--- a/src/lib/scheduling-config-validation.ts
+++ b/src/lib/scheduling-config-validation.ts
@@ -1,0 +1,66 @@
+import { prisma } from '@/lib/prisma';
+
+export type ValidationWarning = {
+  code: string;
+  message: string;
+};
+
+export type EffectiveCfg = {
+  markTeacherConflict: boolean;
+  markStudentConflict: boolean;
+  markBoothConflict: boolean;
+  markTeacherUnavailable: boolean;
+  markStudentUnavailable: boolean;
+  markTeacherWrongTime: boolean;
+  markStudentWrongTime: boolean;
+  markNoSharedAvailability: boolean;
+  allowOutsideAvailabilityTeacher: boolean;
+  allowOutsideAvailabilityStudent: boolean;
+  generationMonths: number;
+};
+
+export function validateEffectiveConfig(cfg: EffectiveCfg): ValidationWarning[] {
+  const warnings: ValidationWarning[] = [];
+
+  if (!Number.isFinite(cfg.generationMonths) || cfg.generationMonths < 1) {
+    warnings.push({ code: 'GEN_MONTHS_MIN', message: `generationMonths must be >= 1 (got ${cfg.generationMonths})` });
+  }
+  if (cfg.generationMonths > 12) {
+    warnings.push({ code: 'GEN_MONTHS_MAX', message: `generationMonths is large (${cfg.generationMonths}); consider <= 12` });
+  }
+  const tri = [cfg.markTeacherConflict, cfg.markStudentConflict, cfg.markBoothConflict];
+  if (!tri.some(Boolean)) {
+    warnings.push({ code: 'ALL_CONFLICT_FLAGS_OFF', message: 'All conflict flags are disabled; conflicts will never be marked.' });
+  }
+  return warnings;
+}
+
+export async function maybeReportSchedulingWarnings(
+  ctx: { branchId?: string | null; seriesId?: string | null },
+  warnings: ValidationWarning[]
+): Promise<void> {
+  if (!warnings.length) return;
+  const recipientType = 'SYSTEM';
+  const recipientId = process.env.ADMIN_NOTIFY_RECIPIENT || 'ADMIN';
+  const notificationType = 'SCHEDULING_CONFIG_WARNING';
+  const today = new Date(); today.setUTCHours(0,0,0,0);
+  const msgPrefix = ctx.seriesId ? `[series=${ctx.seriesId}]` : `[branch=${ctx.branchId ?? 'GLOBAL'}]`;
+  const message = `${msgPrefix} ${warnings.map(w => `${w.code}:${w.message}`).join('; ')}`.slice(0, 1800);
+  try {
+    await prisma.notification.create({
+      data: {
+        recipientType,
+        recipientId,
+        notificationType,
+        message,
+        branchId: ctx.branchId ?? null,
+        targetDate: today,
+        status: 'PENDING' as any,
+      },
+    });
+  } catch (e) {
+    // best-effort; avoid throwing in hot path
+    console.warn('scheduling-config warning could not be recorded:', (e as Error)?.message);
+  }
+}
+

--- a/src/lib/scheduling-config.ts
+++ b/src/lib/scheduling-config.ts
@@ -93,6 +93,40 @@ export async function getEffectiveSchedulingConfig(
 }
 
 /**
+ * Apply a per-series JSON override on top of an existing effective config.
+ * Only properties present in the override are applied.
+ */
+export function applySeriesOverride(
+  base: EffectiveSchedulingConfig,
+  override: Partial<EffectiveSchedulingConfig> | null | undefined
+): EffectiveSchedulingConfig {
+  if (!override || typeof override !== 'object') return base;
+  return {
+    markTeacherConflict: override.markTeacherConflict ?? base.markTeacherConflict,
+    markStudentConflict: override.markStudentConflict ?? base.markStudentConflict,
+    markBoothConflict: override.markBoothConflict ?? base.markBoothConflict,
+    markTeacherUnavailable:
+      override.markTeacherUnavailable ?? base.markTeacherUnavailable,
+    markStudentUnavailable:
+      override.markStudentUnavailable ?? base.markStudentUnavailable,
+    markTeacherWrongTime:
+      override.markTeacherWrongTime ?? base.markTeacherWrongTime,
+    markStudentWrongTime:
+      override.markStudentWrongTime ?? base.markStudentWrongTime,
+    markNoSharedAvailability:
+      override.markNoSharedAvailability ?? base.markNoSharedAvailability,
+    allowOutsideAvailabilityTeacher:
+      override.allowOutsideAvailabilityTeacher ?? base.allowOutsideAvailabilityTeacher,
+    allowOutsideAvailabilityStudent:
+      override.allowOutsideAvailabilityStudent ?? base.allowOutsideAvailabilityStudent,
+    generationMonths: Math.max(
+      1,
+      Number(override.generationMonths ?? base.generationMonths)
+    ),
+  };
+}
+
+/**
  * Convert effective config into the existing `conflictPolicy` response shape
  * expected by the frontend.
  */

--- a/tests/integration/class-series-generation.test.ts
+++ b/tests/integration/class-series-generation.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { applySeriesOverride, getEffectiveSchedulingConfig } from '@/lib/scheduling-config';
+import { advanceGenerateForSeries } from '@/lib/series-advance';
+import { toZonedTime, formatInTimeZone } from 'date-fns-tz';
+
+// Simple stub of PrismaClient methods used by advanceGenerateForSeries
+function makeMockPrisma() {
+  const series = {
+    seriesId: 'S1',
+    branchId: 'B1',
+    teacherId: 'T1',
+    studentId: 'ST1',
+    subjectId: null as string | null,
+    classTypeId: null as string | null,
+    boothId: null as string | null,
+    startDate: new Date(Date.UTC(2025, 8, 24, 0, 0, 0, 0)), // 2025-09-24
+    endDate: new Date(Date.UTC(2025, 8, 30, 0, 0, 0, 0)),
+    startTime: new Date(Date.UTC(2000, 0, 1, 10, 0, 0, 0)),
+    endTime: new Date(Date.UTC(2000, 0, 1, 10, 50, 0, 0)),
+    duration: 50,
+    daysOfWeek: [3, 5], // Wed, Fri
+    status: 'ACTIVE',
+    lastGeneratedThrough: null as Date | null,
+    notes: null as string | null,
+    schedulingOverride: { generationMonths: 2 },
+  } as any;
+
+  const sessions: Array<{ date: Date; startTime: Date; endTime: Date; classId: string; seriesId: string }>
+    = [];
+
+  const prisma: any = {
+    classSeries: {
+      findUnique: async ({ where: { seriesId } }: any) => seriesId === series.seriesId ? series : null,
+      update: async ({ data }: any) => { series.lastGeneratedThrough = data.lastGeneratedThrough; return series; },
+      delete: async () => { return {}; },
+    },
+    classSession: {
+      findMany: async ({ where: { date } }: any) => sessions.filter(s => date.in.some((d: Date) => d.getTime() === s.date.getTime())),
+      findFirst: async ({ where: { seriesId, date, startTime, endTime } }: any) =>
+        sessions.find(s => s.seriesId === seriesId && s.date.getTime() === date.getTime() && s.startTime.getUTCHours() === startTime.getUTCHours() && s.startTime.getUTCMinutes() === startTime.getUTCMinutes() && s.endTime.getUTCHours() === endTime.getUTCHours() && s.endTime.getUTCMinutes() === endTime.getUTCMinutes()) || null,
+      create: async ({ data }: any) => { const classId = `C${sessions.length+1}`; sessions.push({ classId, seriesId: data.seriesId, date: data.date, startTime: data.startTime, endTime: data.endTime }); return { classId }; },
+    },
+    vacation: { findMany: async () => [] },
+    classType: { findUnique: async () => null },
+    $queryRaw: async () => [{ pg_try_advisory_lock: true }],
+  };
+  return { prisma, series, sessions };
+}
+
+describe('config precedence and idempotency (integration-ish)', () => {
+  it('applies per-series override over branch/global for generationMonths', async () => {
+    const global = await getEffectiveSchedulingConfig(null);
+    const withBranch = { ...global, generationMonths: 3 }; // pretend branch override
+    const wSeries = applySeriesOverride(withBranch, { generationMonths: 2 });
+    expect(wSeries.generationMonths).toBe(2);
+  });
+
+  it('advanceGenerateForSeries is idempotent when re-run', async () => {
+    const { prisma, sessions } = makeMockPrisma();
+    const res1 = await advanceGenerateForSeries(prisma as any, 'S1', { leadDays: 10 });
+    expect(res1.attempted).toBeGreaterThan(0);
+    const countAfterFirst = sessions.length;
+    expect(countAfterFirst).toBe(res1.createdConfirmed + res1.createdConflicted);
+
+    const res2 = await advanceGenerateForSeries(prisma as any, 'S1', { leadDays: 10 });
+    expect(sessions.length).toBe(countAfterFirst); // no new sessions
+    expect(res2.createdConfirmed + res2.createdConflicted).toBe(0);
+  });
+  
+  it('generates DST-correct times when timezone is set (America/New_York)', async () => {
+    // DST ends Nov 2, 2025 in New York; 10:00 local should remain 10:00 local across boundary
+    const series = {
+      seriesId: 'S_TZ',
+      branchId: 'B1',
+      teacherId: null,
+      studentId: null,
+      subjectId: null,
+      classTypeId: null,
+      boothId: null,
+      startDate: new Date(Date.UTC(2025, 9, 31, 0, 0, 0, 0)), // 2025-10-31
+      endDate: new Date(Date.UTC(2025, 10, 5, 0, 0, 0, 0)),   // 2025-11-05
+      startTime: new Date(Date.UTC(2000,0,1,10,0,0,0)),
+      endTime: new Date(Date.UTC(2000,0,1,10,50,0,0)),
+      duration: 50,
+      daysOfWeek: [0,3,5], // include Sun, Wed, Fri
+      status: 'ACTIVE',
+      lastGeneratedThrough: null as Date | null,
+      notes: null as string | null,
+      timezone: 'America/New_York',
+    } as any;
+
+    const sessions: any[] = [];
+    const datesIn = (start: Date, end: Date) => {
+      const arr: Date[] = [];
+      for (let d = new Date(start); d <= end; d = new Date(d.getTime() + 86400000)) arr.push(new Date(d));
+      return arr;
+    };
+
+    const prisma: any = {
+      classSeries: { findUnique: async () => series, update: async ({ data }: any) => { series.lastGeneratedThrough = data.lastGeneratedThrough; }, delete: async () => {} },
+      classSession: {
+        findMany: async ({ where: { date } }: any) => sessions.filter(s => date.in.some((d: Date) => d.getTime() === s.date.getTime())),
+        findFirst: async () => null,
+        create: async ({ data }: any) => { sessions.push(data); return { classId: `X${sessions.length}` }; },
+      },
+      vacation: { findMany: async () => [] },
+      classType: { findUnique: async () => null },
+      $queryRaw: async () => [{ pg_try_advisory_lock: true }],
+    };
+
+    await advanceGenerateForSeries(prisma as any, 'S_TZ', { leadDays: 60 });
+    // pick two dates across DST end: Nov 2 and Nov 5
+    const sampleDates = sessions.filter(s => {
+      const y = s.date.getUTCFullYear(); const m = s.date.getUTCMonth()+1; const d = s.date.getUTCDate();
+      return (y===2025 && m===11 && (d===2 || d===5));
+    });
+    expect(sampleDates.length).toBeGreaterThan(0);
+    for (const s of sampleDates) {
+      const hhmm = formatInTimeZone(s.startTime, 'America/New_York', 'HH:mm');
+      expect(hhmm).toBe('10:00');
+    }
+  });
+
+  it('deletes blueprint once endDate boundary is reached, sessions remain', async () => {
+    let deleted = false;
+    const series = {
+      seriesId: 'S_END',
+      branchId: 'B1',
+      teacherId: null,
+      studentId: null,
+      subjectId: null,
+      classTypeId: null,
+      boothId: null,
+      startDate: new Date(Date.UTC(2025, 8, 24, 0, 0, 0, 0)),
+      endDate: new Date(Date.UTC(2025, 8, 24, 0, 0, 0, 0)),
+      startTime: new Date(Date.UTC(2000,0,1,10,0,0,0)),
+      endTime: new Date(Date.UTC(2000,0,1,10,50,0,0)),
+      duration: 50,
+      daysOfWeek: [3],
+      status: 'ACTIVE',
+      lastGeneratedThrough: null as Date | null,
+      notes: null as string | null,
+    } as any;
+    const sessions: any[] = [];
+    const prisma: any = {
+      classSeries: {
+        findUnique: async () => series,
+        update: async () => series,
+        delete: async () => { deleted = true; },
+      },
+      classSession: {
+        findMany: async () => [],
+        findFirst: async () => null,
+        create: async ({ data }: any) => { sessions.push(data); return { classId: 'Y1' }; },
+      },
+      vacation: { findMany: async () => [] },
+      classType: { findUnique: async () => null },
+      $queryRaw: async () => [{ pg_try_advisory_lock: true }],
+    };
+    const res = await advanceGenerateForSeries(prisma as any, 'S_END', { leadDays: 2 });
+    expect(deleted).toBe(true);
+    expect(sessions.length).toBe(1);
+    expect(res.createdConfirmed + res.createdConflicted).toBe(1);
+  });
+
+  it('resumes after interruption by safely re-running', async () => {
+    const series = {
+      seriesId: 'S_RESUME',
+      branchId: 'B1',
+      teacherId: null,
+      studentId: null,
+      subjectId: null,
+      classTypeId: null,
+      boothId: null,
+      startDate: new Date(Date.UTC(2025, 8, 24, 0, 0, 0, 0)),
+      endDate: new Date(Date.UTC(2025, 8, 28, 0, 0, 0, 0)),
+      startTime: new Date(Date.UTC(2000,0,1,10,0,0,0)),
+      endTime: new Date(Date.UTC(2000,0,1,10,50,0,0)),
+      duration: 50,
+      daysOfWeek: [2,3,4,5,6],
+      status: 'ACTIVE',
+      lastGeneratedThrough: null as Date | null,
+      notes: null as string | null,
+    } as any;
+
+    const sessions: any[] = [];
+    let failPrefetchOnce = true;
+    const prisma: any = {
+      classSeries: { findUnique: async () => series, update: async ({ data }: any) => { series.lastGeneratedThrough = data.lastGeneratedThrough; } },
+      classSession: {
+        findMany: async ({ where: { date } }: any) => { if (failPrefetchOnce) { failPrefetchOnce = false; throw new Error('prefetch failed'); } return sessions.filter(s => date.in.some((d: Date) => d.getTime() === s.date.getTime())); },
+        findFirst: async ({ where: { date, startTime, endTime } }: any) => sessions.find(s => s.date.getTime()===date.getTime() && s.startTime.getUTCHours()===startTime.getUTCHours() && s.startTime.getUTCMinutes()===startTime.getUTCMinutes() && s.endTime.getUTCHours()===endTime.getUTCHours() && s.endTime.getUTCMinutes()===endTime.getUTCMinutes()) || null,
+        create: async ({ data }: any) => { sessions.push(data); return { classId: `R${sessions.length}` }; },
+      },
+      vacation: { findMany: async () => [] },
+      classType: { findUnique: async () => null },
+      $queryRaw: async () => [{ pg_try_advisory_lock: true }],
+    };
+
+    try { await advanceGenerateForSeries(prisma as any, 'S_RESUME', { leadDays: 5 }); } catch {}
+    const firstCount = sessions.length;
+    await advanceGenerateForSeries(prisma as any, 'S_RESUME', { leadDays: 5 });
+    // After re-run, all candidate days should exist (idempotency fills gaps)
+    expect(sessions.length).toBeGreaterThan(firstCount);
+  });
+
+  it('does nothing when advisory lock is not acquired (concurrency guard)', async () => {
+    const series = {
+      seriesId: 'S_LOCK',
+      branchId: 'B1',
+      teacherId: null,
+      studentId: null,
+      subjectId: null,
+      classTypeId: null,
+      boothId: null,
+      startDate: new Date(Date.UTC(2025, 8, 24, 0, 0, 0, 0)),
+      endDate: new Date(Date.UTC(2025, 8, 30, 0, 0, 0, 0)),
+      startTime: new Date(Date.UTC(2000,0,1,10,0,0,0)),
+      endTime: new Date(Date.UTC(2000,0,1,10,50,0,0)),
+      duration: 50,
+      daysOfWeek: [3,5],
+      status: 'ACTIVE',
+      lastGeneratedThrough: null as Date | null,
+      notes: null as string | null,
+    } as any;
+    const prisma: any = {
+      classSeries: { findUnique: async () => series },
+      classSession: { findMany: async () => [], findFirst: async () => null, create: async () => ({ classId: 'Z1' }) },
+      vacation: { findMany: async () => [] },
+      classType: { findUnique: async () => null },
+      $queryRaw: async () => [{ pg_try_advisory_lock: false }],
+    };
+    const res = await advanceGenerateForSeries(prisma as any, 'S_LOCK', { leadDays: 10 });
+    expect(res.attempted).toBe(0);
+    expect(res.createdConfirmed + res.createdConflicted + res.skipped).toBe(0);
+  });
+});


### PR DESCRIPTION
- New: scripts/flow-tests/{run.ts,utils.ts,README.md}
- Orchestrates data setup, cron-equivalent generation, assertions, and prints a compact JSON summary for PRs/issues
- Scenarios: base-setup (JP, Asia/Tokyo), special-overlap (特別授業 → CONFLICTED + auto-cancel, idempotent), teacher/student/booth conflicts, vacation-conflict (CONFLICTED + auto-cancel), idempotency (re-run no new rows), concurrency (advisory lock → no-op), cleanup-end (blueprint deleted, sessions remain)
- Usage: bun run scripts/flow-tests/run.ts [all|base|special-overlap|teacher-conflict|student-conflict| booth-conflict|vacation-conflict|idempotency|concurrency|cleanup-end]
- Timezone: conflict checks compare minutes-of-day (TZ-agnostic); optional per-series timezone keeps local clock stable across DST; default Asia/Tokyo; override with TZ_OVERRIDE=America/New_York
- Validated locally: conflicts and auto-cancel, idempotency, end-of-life cleanup, advisory lock no-op