### PR TITLE
011-create-a-simple: implement password change feature and docs

### DIFF
--- a/specs/011-create-a-simple/contracts/change-password.md
+++ b/specs/011-create-a-simple/contracts/change-password.md
@@ -1,0 +1,78 @@
+# API Contract: POST /api/auth/change-password
+
+This endpoint allows an authenticated user to change their own password.
+
+## Endpoint
+
+- **Method**: `POST`
+- **Path**: `/api/auth/change-password`
+
+## Authorization
+
+- **Required**: Yes
+- **Roles**: `ADMIN`, `STAFF`, `TEACHER`, `STUDENT`
+- The user must be authenticated. The endpoint will use the session to identify the user.
+
+## Request Body
+
+The request body must be a JSON object matching the following Zod schema.
+
+### Zod Schema (`changePasswordSchema`)
+
+```typescript
+import { z } from 'zod';
+
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, { message: "Current password is required." }),
+  newPassword: z.string().min(4, { message: "New password must be at least 4 characters long." }),
+});
+```
+
+### Example Request
+
+```json
+{
+  "currentPassword": "old-password-123",
+  "newPassword": "new-password-456"
+}
+```
+
+## Responses
+
+### 200 OK - Success
+
+Returned when the password has been successfully updated.
+
+```json
+{
+  "message": "Password changed successfully."
+}
+```
+
+### 400 Bad Request
+
+Returned for validation errors (e.g., missing fields, new password too short).
+
+```json
+{
+  "error": "New password must be at least 4 characters long."
+}
+```
+
+### 401 Unauthorized
+
+Returned if the user is not authenticated.
+
+### 403 Forbidden
+
+Returned if the `currentPassword` does not match the user's actual current password.
+
+```json
+{
+  "error": "Incorrect current password."
+}
+```
+
+### 500 Internal Server Error
+
+Returned for any unexpected server-side errors.

--- a/specs/011-create-a-simple/data-model.md
+++ b/specs/011-create-a-simple/data-model.md
@@ -1,0 +1,22 @@
+# Data Model: Password Change
+
+This feature primarily interacts with the existing `User` entity. No new models are required.
+
+## User Entity
+
+Represents an individual with access to the system. The password change logic will read and update fields on this model.
+
+- **Source**: `prisma/schema.prisma`
+- **Model**: `User`
+
+### Relevant Fields
+
+| Field | Type | Description | Notes |
+|---|---|---|---|
+| `id` | `String` | Unique identifier for the user. | `@id @default(cuid())` |
+| `password` | `String?` | The user's password. Hashed for Admin/Staff, plaintext for others. | Optional field. |
+| `role` | `UserRole` | The user's role in the system. | Enum: `ADMIN`, `STAFF`, `TEACHER`, `STUDENT`. |
+
+### State Transitions
+
+The `password` field is the only one that changes. The value is updated upon successful completion of the password change flow. The logic is conditional based on the `role` field.

--- a/specs/011-create-a-simple/plan.md
+++ b/specs/011-create-a-simple/plan.md
@@ -1,0 +1,53 @@
+
+# Implementation Plan: Password Change UI
+
+**Branch**: `011-create-a-simple` | **Date**: 2025-10-03 | **Spec**: [./spec.md](./spec.md)
+**Input**: Feature specification from `/specs/011-create-a-simple/spec.md`
+
+## Summary
+This plan outlines the implementation of a simple UI for users of all roles (Admin, Staff, Teacher, Student) to change their own passwords. The UI will be a modal dialog accessible from the user menu dropdown. The technical approach involves creating a new API endpoint (`/api/auth/change-password`) that handles password verification and updates conditionally based on user role, using `bcryptjs` for hashing where required. The frontend will be a new React component using `shadcn/ui` and TanStack Query for state management.
+
+## Technical Context
+**Language/Version**: TypeScript (Next.js)
+**Primary Dependencies**: Next.js, NextAuth.js v5, Prisma, react-hook-form, zod, TanStack Query, shadcn/ui, bcryptjs
+**Storage**: PostgreSQL (via Prisma)
+**Testing**: Manual testing as per quickstart.
+**Target Platform**: Web
+**Project Type**: Web
+**Structure Decision**: Option 2: Web application
+
+## Constitution Check
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- All principles adhered to. No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+```
+specs/011-create-a-simple/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── change-password.md # Phase 1 output
+└── tasks.md             # Phase 2 output
+```
+
+## Progress Tracking
+*This checklist is updated during execution flow*
+
+**Phase Status**:
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [x] Phase 2: Task planning complete (/plan command - describe approach only)
+- [x] Phase 3: Tasks generated (/tasks command)
+- [x] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [x] All NEEDS CLARIFICATION resolved
+- [x] Complexity deviations documented: None

--- a/specs/011-create-a-simple/quickstart.md
+++ b/specs/011-create-a-simple/quickstart.md
@@ -1,0 +1,50 @@
+# Quickstart: Implementing the Password Change UI
+
+This guide outlines the essential steps to implement the password change feature based on the provided design artifacts.
+
+## 1. Backend: API Route
+
+- **File**: `src/app/api/auth/change-password/route.ts`
+- **Action**: Create a new `POST` handler.
+- **Logic**:
+    1.  Verify the user is authenticated by getting the session from NextAuth.
+    2.  Validate the request body using the `changePasswordSchema` from `src/schemas/auth.ts` (you will create this schema).
+    3.  Fetch the user from the database using the ID from the session.
+    4.  Check the user's role (`ADMIN`, `STAFF`, `TEACHER`, `STUDENT`).
+    5.  **Conditional Password Verification**:
+        - If `ADMIN` or `STAFF`, use `bcrypt.compare()` to check `currentPassword` against the hashed password.
+        - If `TEACHER` or `STUDENT`, use direct string comparison (`===`).
+    6.  If verification fails, return a 403 error.
+    7.  **Conditional Password Update**:
+        - If `ADMIN` or `STAFF`, hash the `newPassword` with `bcrypt.hash()`.
+        - If `TEACHER` or `STUDENT`, use the `newPassword` as plaintext.
+    8.  Update the user in the database with the new password value using `prisma.user.update()`.
+    9.  Return a 200 success response.
+
+## 2. Frontend: UI Component & State
+
+### a. Create the Form Component
+
+- **File**: `src/components/auth/password-change-form.tsx`
+- **Action**: Create a new React component.
+- **UI**:
+    - Use `shadcn/ui` components: `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `Form`, `FormField`, `Input`, `Button`.
+    - The form should have two fields: `currentPassword` (type `password`) and `newPassword` (type `password`).
+    - Use `react-hook-form` with a `zodResolver` pointing to the `changePasswordSchema` for client-side validation.
+
+### b. Implement State Management
+
+- **File**: `src/hooks/use-auth-mutations.ts` (or similar)
+- **Action**: Create a new `useMutation` hook for changing the password.
+- **Logic**:
+    - Use TanStack Query's `useMutation` to call the `POST /api/auth/change-password` endpoint.
+    - In the `PasswordChangeForm` component, call this mutation `onSubmit`.
+    - Use the mutation's `isPending`, `isError`, and `isSuccess` states to provide feedback to the user (e.g., disable the button while pending, show a success/error toast message).
+
+## 3. Integration: User Menu
+
+- **File**: `src/components/layout/user-nav.tsx` (or the component that renders the user menu dropdown).
+- **Action**: Add a `<PasswordChangeDialog />` component.
+- **Logic**:
+    - The `PasswordChangeDialog` will wrap the `PasswordChangeForm` and control the open/closed state of the `Dialog`.
+    - Add a `<DropdownMenuItem>` with the text "Change Password" that, when clicked, opens the dialog.

--- a/specs/011-create-a-simple/research.md
+++ b/specs/011-create-a-simple/research.md
@@ -1,0 +1,28 @@
+# Research & Analysis for Password Change UI
+
+## 1. Technical Stack & Dependencies
+- **Decision**: Use existing project stack: Next.js, React, TypeScript, NextAuth.js v5, Prisma, and `bcryptjs` for hashing.
+- **Rationale**: The project conventions are well-established. `bcryptjs` is a suitable library for password hashing and is likely already in use or can be easily added. The feature is a standard web UI, so no new dependencies are required.
+- **Alternatives Considered**: None, to maintain consistency with the existing codebase.
+
+## 2. API Endpoint Design
+- **Decision**: Create a new API route at `POST /api/auth/change-password`.
+- **Rationale**: Placing this under `/api/auth` is consistent with NextAuth's patterns. A `POST` request is appropriate for submitting a form that changes state. The request will be handled by a custom API route that is protected and can access the user's session.
+- **Alternatives Considered**: A `PUT` request to `/api/users/[id]/password`, but this is less secure as it exposes user IDs and is less aligned with auth-specific actions.
+
+## 3. UI Implementation & Location
+- **Decision**: The UI will be a modal dialog containing a form. This dialog will be triggered by a "Change Password" link in the user menu dropdown.
+- **Rationale**: This was clarified and decided upon in the previous step. A modal is a non-disruptive way to handle a simple, focused task like changing a password. It will be built using `shadcn/ui` components (`Dialog`, `Form`, `Input`, `Button`) to match the existing UI.
+- **Alternatives Considered**: A dedicated settings page, but this was deemed too heavyweight for a single action as per the clarification phase.
+
+## 4. Password Handling Logic
+- **Decision**:
+    - For **Admin** and **Staff** roles: The API will compare the provided `currentPassword` with the hashed password in the database using `bcrypt.compare()`. The `newPassword` will be hashed using `bcrypt.hash()` before being saved.
+    - For **Teacher** and **Student** roles: The API will perform a direct string comparison for the `currentPassword` and save the `newPassword` as plaintext, as per the spec's explicit requirement.
+- **Rationale**: This directly implements the logic specified in `FR-003` and `FR-004`. It requires a conditional check in the API route based on the user's role, which is available in the NextAuth session.
+- **Alternatives Considered**: Hashing all passwords. This was rejected as it violates the explicit (though unusual) requirement to store Teacher/Student passwords in plaintext.
+
+## 5. State Management
+- **Decision**: Use TanStack Query's `useMutation` hook to handle the form submission.
+- **Rationale**: The project already uses TanStack Query for server state. A mutation is the correct pattern for an action that modifies data on the server. It provides built-in state handling for loading, error, and success states, which can be used to give the user feedback in the UI.
+- **Alternatives Considered**: Using local component state (`useState`). This is simpler but provides less robust handling of the async server request lifecycle.

--- a/specs/011-create-a-simple/spec.md
+++ b/specs/011-create-a-simple/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: Password Change UI
+
+**Feature Branch**: `011-create-a-simple`  
+**Created**: 2025-10-03  
+**Status**: Draft  
+**Input**: User description: "Create a simple UI that allows admins, staff, teachers, and students to change their passwords, since currently no such UI exists. Use shadcn components for the implementation and follow existing code patterns for consistency. Decide the most appropriate place in the application to add this UI. Ensure that teacher and student passwords are treated as plain text, while maintaining the expected behavior for admin and staff password handling."
+
+## Clarifications
+### Session 2025-10-03
+- Q: What are the existing security measures for Admin and Staff passwords? → A: Hashing with a salt
+- Q: Where is the most appropriate place to add the password change UI? → A: Add a "Change Password" link to the user menu dropdown (e.g., where "Logout" is).
+- Q: What password complexity requirements, if any, should be enforced for each role? → A: Minimum 4 characters for all roles.
+- Q: How should the system handle a user trying to change their password to their old password? → A: Allow it. The user can reuse their old password.
+
+## Execution Flow (main)
+```
+1. Parse user description from Input
+   → If empty: ERROR "No feature description provided"
+2. Extract key concepts from description
+   → Identify: actors, actions, data, constraints
+3. For each unclear aspect:
+   → Mark with [NEEDS CLARIFICATION: specific question]
+4. Fill User Scenarios & Testing section
+   → If no clear user flow: ERROR "Cannot determine user scenarios"
+5. Generate Functional Requirements
+   → Each requirement must be testable
+   → Mark ambiguous requirements
+6. Identify Key Entities (if data involved)
+7. Run Review Checklist
+   → If any [NEEDS CLARIFICATION]: WARN "Spec has uncertainties"
+   → If implementation details found: ERROR "Remove tech details"
+8. Return: SUCCESS (spec ready for planning)
+```
+
+---
+
+## ⚡ Quick Guidelines
+- ✅ Focus on WHAT users need and WHY
+- ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
+- 👥 Written for business stakeholders, not developers
+
+### Section Requirements
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+When creating this spec from a user prompt:
+1. **Mark all ambiguities**: Use [NEEDS CLARIFICATION: specific question] for any assumption you'd need to make
+2. **Don't guess**: If the prompt doesn't specify something (e.g., "login system" without auth method), mark it
+3. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+4. **Common underspecified areas**:
+   - User types and permissions
+   - Data retention/deletion policies  
+   - Performance targets and scale
+   - Error handling behaviors
+   - Integration requirements
+   - Security/compliance needs
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### Primary User Story
+As a user (Admin, Staff, Teacher, or Student), I want to be able to change my password within the application so that I can manage my own account security.
+
+### Acceptance Scenarios
+1. **Given** an Admin is logged in, **When** they navigate to the password change UI and submit a new password, **Then** their password is changed.
+2. **Given** a Staff member is logged in, **When** they navigate to the password change UI and submit a new password, **Then** their password is changed.
+3. **Given** a Teacher is logged in, **When** they navigate to the password change UI and submit a new password, **Then** their password is changed.
+4. **Given** a Student is logged in, **When** they navigate to the password change UI and submit a new password, **Then** their password is changed.
+
+### Edge Cases
+- What happens when a user enters a new password that does not meet the complexity requirements?
+- What happens if a user's session expires while they are on the change password page?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+- **FR-001**: The system MUST provide a user interface for users to change their password.
+- **FR-002**: The password change UI MUST be accessible to Admin, Staff, Teacher, and Student roles.
+- **FR-003**: The system MUST treat passwords for Teacher and Student roles as plain text.
+- **FR-004**: The system MUST handle Admin and Staff passwords by hashing them with a salt.
+- **FR-005**: The password change UI MUST be accessible via a "Change Password" link in the user menu dropdown.
+- **FR-006**: The system MUST enforce a minimum password length of 4 characters for all roles.
+- **FR-007**: The system MUST allow a user to change their password to their previous password.
+
+### Key Entities *(include if feature involves data)*
+- **User**: Represents an individual with access to the system. Key attributes: `role` (Admin, Staff, Teacher, Student), `password`.
+
+---
+
+## Review & Acceptance Checklist
+*GATE: Automated checks run during main() execution*
+
+### Content Quality
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+### Requirement Completeness
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous  
+- [ ] Success criteria are measurable
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+---
+
+## Execution Status
+*Updated by main() during processing*
+
+- [ ] User description parsed
+- [ ] Key concepts extracted
+- [ ] Ambiguities marked
+- [- [ ] User scenarios defined
+- [ ] Requirements generated
+- [ ] Entities identified
+- [ ] Review checklist passed
+
+---

--- a/specs/011-create-a-simple/tasks.md
+++ b/specs/011-create-a-simple/tasks.md
@@ -1,0 +1,43 @@
+# Implementation Tasks: Password Change UI
+
+This plan breaks down the work into sequential and parallelizable tasks. Follow the TDD (Test-Driven Development) principle where applicable.
+
+## Phase 1: Backend API
+
+### Backend Setup
+
+- [x] 1. **[Schema]** Define/update the Zod schema for the change password request body in `src/schemas/password.schema.ts`. The schema validates `currentPassword`, `newPassword` (min 4), and `confirmPassword`.
+- [x] 2. **[Dependency]** `bcryptjs` is already a dependency.
+
+### API Route Implementation
+
+- [x] 3. **[API]** Implement role-scoped routes aligning with existing patterns:
+  - `PATCH src/app/api/admins/me/password/route.ts` (hashed)
+  - `PATCH src/app/api/staffs/me/password/route.ts` (hashed)
+  - Reuse existing `teachers/students` routes (plaintext)
+- [x] 4. **[API]** Each handler validates session and body, fetches user, verifies current password (role-conditional), and updates password accordingly with appropriate errors.
+
+## Phase 2: Frontend UI & State
+
+### State Management Hook
+
+- [x] 10. **[Frontend] [P]** Add `src/hooks/usePasswordChange.ts` using TanStack Query and `fetcher`, routing to role-specific endpoints.
+
+### Form Component
+
+- [x] 11. **[Frontend] [P]** Create the `PasswordChangeForm` component in `src/components/auth/password-change-form.tsx`.
+- [x] 12. **[Frontend]** Build the form UI using `shadcn/ui` components with fields for `currentPassword`, `newPassword`, and `confirmPassword`.
+- [x] 13. **[Frontend]** Integrate `react-hook-form` and the Zod schema for client-side validation.
+- [x] 14. **[Frontend]** Wire the form's `onSubmit` handler to the `usePasswordChange` hook.
+- [x] 15. **[Frontend]** Add loading state and toasts via `sonner`.
+
+## Phase 3: Integration & Finalization
+
+### Dialog and Menu Integration
+
+- [x] 16. **[Integration]** Add "パスワード変更" entry in `src/components/user-profile-menu.tsx` that opens a Dialog with `PasswordChangeForm`.
+
+### Testing & Review
+
+- [ ] 19. **[Testing]** Manually test the end-to-end flow for all four user roles (Admin, Staff, Teacher, Student) to verify correct behavior.
+- [ ] 20. **[Review]** Create a Pull Request, review the code for adherence to project standards, and merge upon approval.

--- a/src/app/api/admins/me/password/route.ts
+++ b/src/app/api/admins/me/password/route.ts
@@ -1,0 +1,58 @@
+// src/app/api/admins/me/password/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { passwordUpdateSchema } from "@/schemas/password.schema";
+import bcrypt from "bcryptjs";
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const session = await auth();
+
+    if (!session || !session.user) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
+    if (session.user.role !== "ADMIN") {
+      return NextResponse.json({ error: "管理者のみがこの機能を使用できます" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const result = passwordUpdateSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { currentPassword, newPassword } = result.data;
+
+    const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+    if (!user) {
+      return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+    }
+
+    // Admin uses hashed passwords
+    if (!user.passwordHash) {
+      return NextResponse.json({ error: "現在のパスワードが設定されていません" }, { status: 400 });
+    }
+
+    const ok = await bcrypt.compare(currentPassword, user.passwordHash);
+    if (!ok) {
+      return NextResponse.json({ error: "現在のパスワードが正しくありません" }, { status: 400 });
+    }
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash: hashed },
+    });
+
+    return NextResponse.json({ message: "パスワードが正常に更新されました" });
+  } catch (error) {
+    console.error("Error updating admin password:", error);
+    return NextResponse.json({ error: "パスワードの更新に失敗しました" }, { status: 500 });
+  }
+}
+

--- a/src/app/api/staffs/me/password/route.ts
+++ b/src/app/api/staffs/me/password/route.ts
@@ -1,0 +1,58 @@
+// src/app/api/staffs/me/password/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { passwordUpdateSchema } from "@/schemas/password.schema";
+import bcrypt from "bcryptjs";
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const session = await auth();
+
+    if (!session || !session.user) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
+    if (session.user.role !== "STAFF") {
+      return NextResponse.json({ error: "スタッフのみがこの機能を使用できます" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const result = passwordUpdateSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { currentPassword, newPassword } = result.data;
+
+    const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+    if (!user) {
+      return NextResponse.json({ error: "ユーザーが見つかりません" }, { status: 404 });
+    }
+
+    // Staff uses hashed passwords
+    if (!user.passwordHash) {
+      return NextResponse.json({ error: "現在のパスワードが設定されていません" }, { status: 400 });
+    }
+
+    const ok = await bcrypt.compare(currentPassword, user.passwordHash);
+    if (!ok) {
+      return NextResponse.json({ error: "現在のパスワードが正しくありません" }, { status: 400 });
+    }
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash: hashed },
+    });
+
+    return NextResponse.json({ message: "パスワードが正常に更新されました" });
+  } catch (error) {
+    console.error("Error updating staff password:", error);
+    return NextResponse.json({ error: "パスワードの更新に失敗しました" }, { status: 500 });
+  }
+}
+

--- a/src/components/auth/password-change-form.tsx
+++ b/src/components/auth/password-change-form.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { passwordUpdateSchema, type PasswordUpdateValues } from "@/schemas/password.schema";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { usePasswordChange } from "@/hooks/usePasswordChange";
+
+type Props = {
+  onSuccess?: () => void;
+};
+
+export function PasswordChangeForm({ onSuccess }: Props) {
+  const form = useForm<PasswordUpdateValues>({
+    resolver: zodResolver(passwordUpdateSchema),
+    defaultValues: { currentPassword: "", newPassword: "", confirmPassword: "" },
+  });
+
+  const mutation = usePasswordChange();
+
+  async function onSubmit(values: PasswordUpdateValues) {
+    await mutation.mutateAsync(values);
+    if (onSuccess) onSuccess();
+    form.reset();
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="currentPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>現在のパスワード</FormLabel>
+              <FormControl>
+                <Input type="password" autoComplete="current-password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="newPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>新しいパスワード</FormLabel>
+              <FormControl>
+                <Input type="password" autoComplete="new-password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>新しいパスワード（確認）</FormLabel>
+              <FormControl>
+                <Input type="password" autoComplete="new-password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="submit" disabled={mutation.isPending}>
+            {mutation.isPending ? "更新中..." : "パスワードを更新"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+

--- a/src/components/user-profile-menu.tsx
+++ b/src/components/user-profile-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { LogOut } from "lucide-react";
+import { LogOut, KeyRound } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -12,9 +12,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { signOut, useSession } from "next-auth/react";
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { PasswordChangeForm } from "@/components/auth/password-change-form";
 
 export default function UserProfileMenu() {
   const { data: session } = useSession({ required: true });
+  const [open, setOpen] = useState(false);
 
   if (!session) {
     return (
@@ -41,32 +45,47 @@ export default function UserProfileMenu() {
       : "/dashboard";
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger>
-        <Avatar>
-          <AvatarImage
-            src={session.user?.image ?? ""}
-            alt={session.user?.name ?? ""}
-          />
-          <AvatarFallback>{userInitials}</AvatarFallback>
-        </Avatar>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuLabel className="font-semibold">
-          {session.user?.name}
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          <Avatar>
+            <AvatarImage
+              src={session.user?.image ?? ""}
+              alt={session.user?.name ?? ""}
+            />
+            <AvatarFallback>{userInitials}</AvatarFallback>
+          </Avatar>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel className="font-semibold">
+            {session.user?.name}
+            <DropdownMenuSeparator />
+            {session.user?.email}
+          </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {session.user?.email}
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => signOut()}>
-          <span className="flex items-center">
-            <LogOut className="mr-2 h-4 w-4" />
-            ログアウト
-          </span>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <DropdownMenuItem onClick={() => setOpen(true)}>
+            <span className="flex items-center">
+              <KeyRound className="mr-2 h-4 w-4" />
+              パスワード変更
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => signOut()}>
+            <span className="flex items-center">
+              <LogOut className="mr-2 h-4 w-4" />
+              ログアウト
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>パスワード変更</DialogTitle>
+          </DialogHeader>
+          <PasswordChangeForm onSuccess={() => setOpen(false)} />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/hooks/usePasswordChange.ts
+++ b/src/hooks/usePasswordChange.ts
@@ -1,0 +1,48 @@
+import { useMutation } from "@tanstack/react-query";
+import { fetcher } from "@/lib/fetcher";
+import { useSession } from "next-auth/react";
+import { PasswordUpdateValues } from "@/schemas/password.schema";
+import { toast } from "sonner";
+
+interface PasswordChangeResponse {
+  message: string;
+}
+
+function endpointForRole(role?: string) {
+  switch (role) {
+    case "ADMIN":
+      return "/api/admins/me/password";
+    case "STAFF":
+      return "/api/staffs/me/password";
+    case "TEACHER":
+      return "/api/teachers/me/password";
+    case "STUDENT":
+      return "/api/students/me/password";
+    default:
+      return "/api/students/me/password"; // sensible default; will fail on server if unauthorized
+  }
+}
+
+export function usePasswordChange() {
+  const { data } = useSession();
+  const role = data?.user?.role;
+
+  return useMutation<PasswordChangeResponse, Error, PasswordUpdateValues>({
+    mutationFn: async (values) => {
+      const url = endpointForRole(role);
+      const res = await fetcher<PasswordChangeResponse>(url, {
+        method: "PATCH",
+        body: JSON.stringify(values),
+      });
+      return res;
+    },
+    onSuccess: (response) => {
+      toast.success(response.message || "パスワードを変更しました");
+    },
+    onError: (error: any) => {
+      const msg = error?.info?.error || error?.message || "パスワードの変更に失敗しました";
+      toast.error(String(msg));
+    },
+  });
+}
+

--- a/src/schemas/password.schema.ts
+++ b/src/schemas/password.schema.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export const passwordUpdateSchema = z.object({
   currentPassword: z.string().min(1, "現在のパスワードを入力してください"),
-  newPassword: z.string().min(6, "新しいパスワードは6文字以上で入力してください"),
+  newPassword: z.string().min(4, "新しいパスワードは4文字以上で入力してください"),
   confirmPassword: z.string().min(1, "確認用パスワードを入力してください"),
 }).refine((data) => data.newPassword === data.confirmPassword, {
   message: "新しいパスワードと確認用パスワードが一致しません",


### PR DESCRIPTION
- add specs (spec, plan, research, contracts, data-model, quickstart, tasks) for password change ui
- implement admin and staff password api routes with bcrypt verification and hashing
- create password change form component, mutation hook, and integrate dialog into user profile menu
- adjust password schema to minimum length 4 and confirm match validation
- add menu entry and toast feedback for password updates across user roles