### PR TITLE
feat(schedule): class type filters across schedule views with per‑role persistence, API support, and styling

### DIFF
--- a/specs/014-we-should-add/contracts/__tests__/class-types.contract.test.ts
+++ b/specs/014-we-should-add/contracts/__tests__/class-types.contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NextResponse } from 'next/server';
+
+// Mock auth to allow ADMIN access
+vi.mock('@/auth', () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: 'u1', role: 'ADMIN' } }),
+}));
+
+// Capture prisma calls
+const countMock = vi.fn();
+const findManyMock = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    classType: {
+      count: (...args: any[]) => countMock(...args),
+      findMany: (...args: any[]) => findManyMock(...args),
+    },
+  },
+}));
+
+// Import after mocks
+import * as route from '@/app/api/class-types/route';
+
+describe('GET /api/class-types (contract)', () => {
+  beforeEach(() => {
+    countMock.mockReset();
+    findManyMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ordered class types with pagination', async () => {
+    countMock.mockResolvedValue(2);
+    findManyMock.mockResolvedValue([
+      { classTypeId: 'b', name: '特別授業', notes: null, parentId: null, order: 2, color: null, parent: null, children: [], createdAt: new Date(), updatedAt: new Date() },
+      { classTypeId: 'a', name: '通常授業', notes: null, parentId: null, order: 1, color: null, parent: null, children: [], createdAt: new Date(), updatedAt: new Date() },
+    ]);
+
+    const url = 'http://localhost/api/class-types?page=1&limit=50';
+    const req: any = { url, headers: new Headers() };
+    const res = (await (route.GET as any)(req)) as NextResponse;
+    const json: any = await (res as any).json();
+
+    expect(json).toBeDefined();
+    expect(json.pagination.total).toBe(2);
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data.length).toBe(2);
+    // Ensure fields present
+    expect(json.data[0]).toHaveProperty('classTypeId');
+    expect(json.data[0]).toHaveProperty('name');
+  });
+});
+

--- a/specs/014-we-should-add/contracts/__tests__/students-me-class-sessions.contract.test.ts
+++ b/specs/014-we-should-add/contracts/__tests__/students-me-class-sessions.contract.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NextResponse } from 'next/server';
+
+// Mock auth to allow STUDENT access
+vi.mock('@/auth', () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: 'u-student', role: 'STUDENT' } }),
+}));
+
+const studentFindFirstMock = vi.fn();
+const classSessionCountMock = vi.fn();
+const classSessionFindManyMock = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    student: { findFirst: (...args: any[]) => studentFindFirstMock(...args) },
+    classSession: {
+      count: (...args: any[]) => classSessionCountMock(...args),
+      findMany: (...args: any[]) => classSessionFindManyMock(...args),
+    },
+  },
+}));
+
+import * as route from '@/app/api/students/me/class-sessions/route';
+
+describe('GET /api/students/me/class-sessions (classTypeIds filter)', () => {
+  beforeEach(() => {
+    studentFindFirstMock.mockReset();
+    classSessionCountMock.mockReset();
+    classSessionFindManyMock.mockReset();
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('applies exact-match IN filter when classTypeIds is provided', async () => {
+    studentFindFirstMock.mockResolvedValue({ studentId: 's1' });
+    classSessionCountMock.mockResolvedValue(1);
+    classSessionFindManyMock.mockResolvedValue([
+      {
+        classId: 'c1', seriesId: null, teacherId: 't1', studentId: 's1', subjectId: null, classTypeId: 'a',
+        boothId: null, branchId: null, date: new Date('2025-01-01T00:00:00Z'),
+        startTime: new Date('2025-01-01T09:00:00Z'), endTime: new Date('2025-01-01T10:00:00Z'),
+        duration: 60, notes: null, createdAt: new Date(), updatedAt: new Date(),
+        teacher: { name: 'Teacher' }, student: { name: 'Student', gradeYear: null, studentType: { name: null } }, subject: { name: null }, classType: { name: '通常授業' }, booth: { name: null }, branch: { name: null }, status: null,
+      },
+    ]);
+
+    const url = 'http://localhost/api/students/me/class-sessions?startDate=2025-01-01&endDate=2025-01-07&classTypeIds=a,b';
+    const req: any = { url, headers: new Headers() };
+    const res = (await (route.GET as any)(req)) as NextResponse;
+    const json: any = await (res as any).json();
+
+    expect(json).toBeDefined();
+    expect(json.data.length).toBe(1);
+    const callArgs = classSessionFindManyMock.mock.calls[0]?.[0] || {};
+    expect(callArgs.where.studentId).toBe('s1');
+    expect(callArgs.where.classTypeId).toEqual({ in: ['a','b'] });
+  });
+});
+

--- a/specs/014-we-should-add/contracts/__tests__/teachers-me-class-sessions.contract.test.ts
+++ b/specs/014-we-should-add/contracts/__tests__/teachers-me-class-sessions.contract.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NextResponse } from 'next/server';
+
+// Mock auth to allow TEACHER access
+vi.mock('@/auth', () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: 'u-teacher', role: 'TEACHER' } }),
+}));
+
+const teacherFindFirstMock = vi.fn();
+const classSessionCountMock = vi.fn();
+const classSessionFindManyMock = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    teacher: { findFirst: (...args: any[]) => teacherFindFirstMock(...args) },
+    classSession: {
+      count: (...args: any[]) => classSessionCountMock(...args),
+      findMany: (...args: any[]) => classSessionFindManyMock(...args),
+    },
+  },
+}));
+
+import * as route from '@/app/api/teachers/me/class-sessions/route';
+
+describe('GET /api/teachers/me/class-sessions (classTypeIds filter)', () => {
+  beforeEach(() => {
+    teacherFindFirstMock.mockReset();
+    classSessionCountMock.mockReset();
+    classSessionFindManyMock.mockReset();
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('applies exact-match IN filter when classTypeIds is provided', async () => {
+    teacherFindFirstMock.mockResolvedValue({ teacherId: 't1' });
+    classSessionCountMock.mockResolvedValue(1);
+    classSessionFindManyMock.mockResolvedValue([
+      {
+        classId: 'c1', seriesId: null, teacherId: 't1', studentId: 's1', subjectId: null, classTypeId: 'a',
+        boothId: null, branchId: null, date: new Date('2025-01-01T00:00:00Z'),
+        startTime: new Date('2025-01-01T09:00:00Z'), endTime: new Date('2025-01-01T10:00:00Z'),
+        duration: 60, notes: null, createdAt: new Date(), updatedAt: new Date(),
+        teacher: { name: 'Teacher' }, student: { name: 'Student', gradeYear: null, studentType: { name: null } }, subject: { name: null }, classType: { name: '通常授業' }, booth: { name: null }, branch: { name: null }, status: null,
+      },
+    ]);
+
+    const url = 'http://localhost/api/teachers/me/class-sessions?startDate=2025-01-01&endDate=2025-01-07&classTypeIds=a,b';
+    const req: any = { url, headers: new Headers() };
+    const res = (await (route.GET as any)(req)) as NextResponse;
+    const json: any = await (res as any).json();
+
+    expect(json).toBeDefined();
+    expect(json.data.length).toBe(1);
+    const callArgs = classSessionFindManyMock.mock.calls[0]?.[0] || {};
+    expect(callArgs.where.teacherId).toBe('t1');
+    expect(callArgs.where.classTypeId).toEqual({ in: ['a','b'] });
+  });
+});
+

--- a/specs/014-we-should-add/contracts/class-types.yaml
+++ b/specs/014-we-should-add/contracts/class-types.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.3
+info:
+  title: Class Types API
+  version: 1.0.0
+paths:
+  /api/class-types:
+    get:
+      summary: List class types
+      parameters:
+        - in: query
+          name: page
+          schema: { type: integer, minimum: 1, default: 1 }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+        - in: query
+          name: name
+          schema: { type: string }
+        - in: query
+          name: parentId
+          schema: { type: string, nullable: true }
+        - in: query
+          name: includeChildren
+          schema: { type: boolean, default: false }
+        - in: query
+          name: includeParent
+          schema: { type: boolean, default: false }
+        - in: query
+          name: sortBy
+          schema: { type: string, enum: [order, name], default: order }
+        - in: query
+          name: sortOrder
+          schema: { type: string, enum: [asc, desc], default: asc }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ClassType'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+components:
+  schemas:
+    ClassType:
+      type: object
+      properties:
+        classTypeId: { type: string }
+        name: { type: string }
+        notes: { type: string, nullable: true }
+        parentId: { type: string, nullable: true }
+        order: { type: integer, nullable: true }
+        color: { type: string, nullable: true }
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClassType'
+    Pagination:
+      type: object
+      properties:
+        total: { type: integer }
+        page: { type: integer }
+        limit: { type: integer }
+        pages: { type: integer }
+

--- a/specs/014-we-should-add/contracts/students-me-class-sessions.yaml
+++ b/specs/014-we-should-add/contracts/students-me-class-sessions.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: Student Me Class Sessions API
+  version: 1.0.0
+paths:
+  /api/students/me/class-sessions:
+    get:
+      summary: List student's class sessions (week/month views)
+      parameters:
+        - in: query
+          name: startDate
+          required: true
+          schema: { type: string, format: date }
+        - in: query
+          name: endDate
+          required: true
+          schema: { type: string, format: date }
+        - in: query
+          name: classTypeIds
+          description: Comma-separated list of classTypeId (multi-select filter). If omitted or empty → all types.
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        classTypeId: { type: string, nullable: true }
+                        classTypeName: { type: string, nullable: true }
+                        subjectName: { type: string, nullable: true }
+                        date: { type: string, format: date }
+                        startTime: { type: string }
+                        endTime: { type: string }
+                        teacherName: { type: string, nullable: true }
+                        studentName: { type: string, nullable: true }
+

--- a/specs/014-we-should-add/contracts/teachers-me-class-sessions.yaml
+++ b/specs/014-we-should-add/contracts/teachers-me-class-sessions.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: Teacher Me Class Sessions API
+  version: 1.0.0
+paths:
+  /api/teachers/me/class-sessions:
+    get:
+      summary: List teacher's class sessions (week/month views)
+      parameters:
+        - in: query
+          name: startDate
+          required: true
+          schema: { type: string, format: date }
+        - in: query
+          name: endDate
+          required: true
+          schema: { type: string, format: date }
+        - in: query
+          name: classTypeIds
+          description: Comma-separated list of classTypeId (multi-select filter). If omitted or empty → all types.
+          schema: { type: string }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        classTypeId: { type: string, nullable: true }
+                        classTypeName: { type: string, nullable: true }
+                        subjectName: { type: string, nullable: true }
+                        date: { type: string, format: date }
+                        startTime: { type: string }
+                        endTime: { type: string }
+                        teacherName: { type: string, nullable: true }
+                        studentName: { type: string, nullable: true }
+

--- a/specs/014-we-should-add/data-model.md
+++ b/specs/014-we-should-add/data-model.md
@@ -1,0 +1,32 @@
+# Data Model: Class Type Filters
+
+## Entities
+
+### ClassType
+- classTypeId: string (UUID)
+- name: string (localized label)
+- parentId: string | null
+- order: number | null
+- color: string | null
+
+Relationships:
+- parent: ClassType | null
+- children: ClassType[]
+
+### FilterState
+- role: "ADMIN" | "STAFF" | "TEACHER" | "STUDENT"
+- selectedClassTypeIds: string[]
+- lastUpdated: ISO timestamp
+
+Constraints:
+- Exact match filtering on `classTypeId` only (no descendant expansion).
+- Persistence key format: `filter:classTypes:{role}` in localStorage (one selection shared across branches).
+
+### ViewVariant
+- value: "DAY" | "WEEK" | "MONTH"
+- appliesTo: Admin/Staff (DAY, WEEK), Teacher/Student (WEEK, MONTH)
+
+## Validation
+- `selectedClassTypeIds` values must exist in `/api/class-types` results.
+- Empty `selectedClassTypeIds` means “All types”.
+

--- a/specs/014-we-should-add/integration-tests/admin-day-filter.test.tsx
+++ b/specs/014-we-should-add/integration-tests/admin-day-filter.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('next-auth/react', () => ({ useSession: () => ({ data: { user: { role: 'ADMIN' } } }) }));
+vi.mock('@/lib/class-type-options', () => ({ fetchClassTypeOptions: vi.fn().mockResolvedValue([]) }));
+
+import { setClassTypeSelection } from '@/lib/class-type-filter-persistence';
+import { DayCalendarFilters } from '@/components/admin-schedule/DayCalendar/day-calendar-filters';
+
+describe('Admin DayCalendarFilters integration', () => {
+  it('initializes classTypeIds from persistence and calls onFiltersChange', async () => {
+    setClassTypeSelection('ADMIN', ['ct-regular']);
+    const onFiltersChange = vi.fn();
+
+    render(
+      <DayCalendarFilters
+        filters={{}}
+        onFiltersChange={onFiltersChange}
+        dateKey={'2025-01-01'}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onFiltersChange).toHaveBeenCalled();
+    });
+    const last = onFiltersChange.mock.calls.pop()?.[0] ?? {};
+    expect(last.classTypeIds).toEqual(['ct-regular']);
+  });
+});
+

--- a/specs/014-we-should-add/integration-tests/student-week-month-filter.test.tsx
+++ b/specs/014-we-should-add/integration-tests/student-week-month-filter.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('next-auth/react', () => ({ useSession: () => ({ data: { user: { role: 'STUDENT' } } }) }));
+vi.mock('@/lib/class-type-options', () => ({ fetchClassTypeOptions: vi.fn().mockResolvedValue([{ value: 'b', label: '特別授業' }]) }));
+
+// Mock Faceted to immediately set a value on mount
+vi.mock('@/components/ui/faceted', () => {
+  return {
+    Faceted: ({ multiple, value, onValueChange, children }: any) => {
+      React.useEffect(() => { onValueChange?.(['b']); }, []);
+      return <div data-testid="faceted">{children}</div>;
+    },
+    FacetedTrigger: (props: any) => <button {...props} />,
+    FacetedBadgeList: (props: any) => <div {...props} />,
+    FacetedContent: (props: any) => <div {...props} />,
+    FacetedInput: (props: any) => <input {...props} />,
+    FacetedList: (props: any) => <div {...props} />,
+    FacetedEmpty: (props: any) => <div {...props} />,
+    FacetedGroup: (props: any) => <div {...props} />,
+    FacetedItem: (props: any) => <div {...props} />,
+  };
+});
+
+const studentHookMock = vi.fn().mockReturnValue({ data: { data: [] }, isPending: false });
+vi.mock('@/hooks/useClassSessionQuery', async (orig) => {
+  const actual: any = await (orig as any)();
+  return {
+    ...actual,
+    useStudentClassSessionsDateRange: (...args: any[]) => studentHookMock(...args),
+  };
+});
+
+import StudentPage from '@/app/student/page';
+
+describe('Student Week/Month filter integration', () => {
+  it('passes classTypeIds to useStudentClassSessionsDateRange when selection changes', async () => {
+    render(<StudentPage />);
+    await waitFor(() => {
+      expect(studentHookMock).toHaveBeenCalled();
+    });
+    const lastArgs = studentHookMock.mock.calls.pop()?.[0];
+    expect(lastArgs.classTypeIds).toEqual(['b']);
+  });
+});
+

--- a/specs/014-we-should-add/integration-tests/teacher-week-month-filter.test.tsx
+++ b/specs/014-we-should-add/integration-tests/teacher-week-month-filter.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+vi.mock('next-auth/react', () => ({ useSession: () => ({ data: { user: { role: 'TEACHER' } } }) }));
+vi.mock('@/lib/class-type-options', () => ({ fetchClassTypeOptions: vi.fn().mockResolvedValue([{ value: 'a', label: '通常授業' }]) }));
+
+// Mock Faceted to immediately set a value on mount
+vi.mock('@/components/ui/faceted', () => {
+  return {
+    Faceted: ({ multiple, value, onValueChange, children }: any) => {
+      React.useEffect(() => { onValueChange?.(['a']); }, []);
+      return <div data-testid="faceted">{children}</div>;
+    },
+    FacetedTrigger: (props: any) => <button {...props} />,
+    FacetedBadgeList: (props: any) => <div {...props} />,
+    FacetedContent: (props: any) => <div {...props} />,
+    FacetedInput: (props: any) => <input {...props} />,
+    FacetedList: (props: any) => <div {...props} />,
+    FacetedEmpty: (props: any) => <div {...props} />,
+    FacetedGroup: (props: any) => <div {...props} />,
+    FacetedItem: (props: any) => <div {...props} />,
+  };
+});
+
+const teacherHookMock = vi.fn().mockReturnValue({ data: { data: [] }, isPending: false });
+vi.mock('@/hooks/useClassSessionQuery', async (orig) => {
+  const actual: any = await (orig as any)();
+  return {
+    ...actual,
+    useTeacherClassSessionsDateRange: (...args: any[]) => teacherHookMock(...args),
+  };
+});
+
+import TeacherPage from '@/app/teacher/page';
+
+describe('Teacher Week/Month filter integration', () => {
+  it('passes classTypeIds to useTeacherClassSessionsDateRange when selection changes', async () => {
+    render(<TeacherPage />);
+    await waitFor(() => {
+      expect(teacherHookMock).toHaveBeenCalled();
+    });
+    const lastArgs = teacherHookMock.mock.calls.pop()?.[0];
+    expect(lastArgs.classTypeIds).toEqual(['a']);
+  });
+});
+

--- a/specs/014-we-should-add/plan.md
+++ b/specs/014-we-should-add/plan.md
@@ -1,0 +1,185 @@
+# Implementation Plan: Class Type Filters Across Schedule Views
+
+**Branch**: `014-we-should-add` | **Date**: 2025-10-07 | **Spec**: specs/014-we-should-add/spec.md
+**Input**: Feature specification from `specs/014-we-should-add/spec.md`
+
+## Execution Flow (/plan command scope)
+```
+1. Load feature spec from Input path
+   → If not found: ERROR "No feature spec at {path}"
+2. Fill Technical Context (scan for NEEDS CLARIFICATION)
+   → Detect Project Type from repository structure (Next.js web app)
+   → Set Structure Decision based on project type
+3. Fill the Constitution Check section based on the constitution document.
+4. Evaluate Constitution Check section below
+   → If violations exist: Document in Complexity Tracking
+   → If no justification possible: ERROR "Simplify approach first"
+   → Update Progress Tracking: Initial Constitution Check
+5. Execute Phase 0 → research.md
+   → Remaining ambiguities are non-blocking; document assumptions
+6. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific file
+7. Re-evaluate Constitution Check section
+   → If new violations: Refactor design, return to Phase 1
+   → Update Progress Tracking: Post-Design Constitution Check
+8. Plan Phase 2 → Describe task generation approach and prepare tasks.md
+9. STOP - Ready for /tasks command
+```
+
+## Summary
+Add a searchable, multi-select Class Type filter across schedule views:
+- Admin/Staff: Daily (日次) and Weekly (週次) tabs
+- Teacher: Week table and Month calendar
+- Student: Week table and Month calendar
+
+Behavior clarified in spec:
+- Multi-select, searchable options (from server API)
+- Persistence: global per role via localStorage, cross-view and across reloads; same across branches
+- Exact match only (no descendants)
+- No selection = all types (no explicit “All” option)
+
+## Technical Context
+**Language/Version**: TypeScript (React 18, Next.js App Router), Bun runtime  
+**Primary Dependencies**: Next.js, React, TanStack Table, React Query, Tailwind CSS v4, Prisma  
+**Storage**: PostgreSQL via Prisma  
+**Testing**: Vitest + React Testing Library (preferred)  
+**Target Platform**: Web (Next.js)  
+**Project Type**: web  
+**Performance Goals**: Filter interactions respond <100ms client-side; no noticeable degradation in schedule rendering  
+**Constraints**: Persist selection per role via localStorage; reuse existing filter patterns/components; avoid schema changes if possible  
+**Scale/Scope**: Typical view sizes: up to a few hundred sessions per week; class type list expected O(10–100)
+
+## Constitution Check
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Simplicity first: reuse existing faceted/combobox patterns → PASS
+- Test-first posture: plan includes contract/integration tests → PASS
+- Observability/versioning constraints: N/A for UI-only change; minimal API changes proposed → PASS
+- Any NEEDS CLARIFICATION blocking? Remaining items are non-blocking (a11y level, locales, empty options behavior) → PASS with notes in research
+
+## Project Structure
+
+### Documentation (this feature)
+```
+specs/014-we-should-add/
+├── plan.md              # This file (/plan output)
+├── research.md          # Phase 0 output (/plan)
+├── data-model.md        # Phase 1 output (/plan)
+├── quickstart.md        # Phase 1 output (/plan)
+├── contracts/           # Phase 1 output (/plan)
+└── tasks.md             # Phase 2 output (/plan prepared; refined by /tasks)
+```
+
+### Source Code (repository root)
+```
+src/
+├── app/
+│   ├── api/
+│   │   ├── class-types/route.ts                 # Class types list API (server source of truth)
+│   │   ├── teachers/me/class-sessions/route.ts  # Accepts classTypeId (extend to multi)
+│   │   └── students/me/class-sessions/route.ts  # Accepts classTypeId (extend to multi)
+│   └── teacher/page.tsx                         # Hosts Week/Month viewer; add filter state
+├── components/
+│   ├── admin-schedule/DayCalendar/day-calendar-filters.tsx   # Add class type filter (admin 日次)
+│   ├── admin-schedule/WeekCalendar/admin-calendar-week.tsx    # Add class type filter (admin 週次)
+│   ├── student-schedule/student-schedule-week-viewer.tsx      # Respect filter
+│   └── student-schedule/student-schedule-month-viewer.tsx     # Respect filter
+└── lib/
+    ├── data-table.ts                          # Filter helpers (reference patterns)
+    └── class-type-colors.ts                   # Legend mapping (informative only)
+```
+
+**Structure Decision**: Web application (Next.js). Modify components under `src/components/*` and, if needed, adjust API handlers under `src/app/api/*` to support multi-select `classTypeIds` in teacher/student “me” endpoints.
+
+## Phase 0: Outline & Research
+1. **Extract unknowns from Technical Context** above:
+   - Accessibility standard: target WCAG 2.1 AA keyboard operability for comboboxes
+   - Localization coverage: prioritize JA; keep strings localizable; EN optional
+   - Empty options behavior: show control disabled with “no class types” hint
+
+2. **Generate and dispatch research agents**:
+   - Patterns: reuse `DataTableFacetedFilter` and `ui/combobox` for multi-select + search
+   - API: `GET /api/class-types` for options; verify pagination and sorting by order then name
+   - Teacher/Student endpoints: assess adding `classTypeIds` vs client-side filtering
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: what was chosen
+   - Rationale: why chosen
+   - Alternatives considered: what else evaluated
+
+**Output**: research.md with key decisions and non-blocking assumptions documented
+
+## Phase 1: Design & Contracts
+*Prerequisites: research.md complete*
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - ClassType, FilterState (per-role persistence), ViewVariant
+
+2. **Generate API contracts** from functional requirements:
+   - `GET /api/class-types` (options; ordered)
+   - `GET /api/teachers/me/class-sessions?classTypeIds=…` (multi-select)
+   - `GET /api/students/me/class-sessions?classTypeIds=…` (multi-select)
+
+3. **Generate contract tests** from contracts:
+   - One test stub per endpoint (schema assertions; initially pending)
+
+4. **Extract test scenarios** from user stories:
+   - Acceptance scenarios 1–11 → integration test plan
+
+5. **Update agent file incrementally**:
+   - Run `.specify/scripts/bash/update-agent-context.sh codex`
+
+**Output**: data-model.md, /contracts/*, contract test stubs, quickstart.md, agent-specific file
+
+## Phase 2: Task Planning Approach
+*This section describes what the /tasks command will do*
+
+**Task Generation Strategy**:
+- Load `.specify/templates/tasks-template.md` as base
+- Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
+- Each contract → contract test task [P]
+- Each entity → model creation task [P]
+- Each user story → integration test task
+- Implementation tasks to make tests pass
+
+**Ordering Strategy**:
+- TDD order: Tests before implementation
+- Dependency order: API contracts → UI filters → wiring → persistence
+- Mark [P] for parallel execution (independent files)
+
+**Estimated Output**: 25-30 numbered, ordered tasks in tasks.md
+
+## Phase 3+: Future Implementation
+*These phases are beyond the scope of the /plan command*
+
+**Phase 3**: Task execution (/tasks command creates tasks.md)  
+**Phase 4**: Implementation (execute tasks.md following constitutional principles)  
+**Phase 5**: Validation (run tests, execute quickstart.md, performance validation)
+
+## Complexity Tracking
+*Fill ONLY if Constitution Check has violations that must be justified*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none) | — | — |
+
+
+## Progress Tracking
+*This checklist is updated during execution flow*
+
+**Phase Status**:
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [x] Phase 2: Task planning complete (/plan command)
+- [ ] Phase 3: Tasks generated (/tasks command)
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [ ] All NEEDS CLARIFICATION resolved (remaining items non-blocking; see research)
+- [ ] Complexity deviations documented
+
+---
+*Based on Constitution v2.1.1 - See `/memory/constitution.md`*
+

--- a/specs/014-we-should-add/quickstart.md
+++ b/specs/014-we-should-add/quickstart.md
@@ -1,0 +1,26 @@
+# Quickstart: Verify Class Type Filters
+
+## Prerequisites
+- Run dev server: `bun dev`
+- Ensure class types exist via `/api/class-types`
+
+## Admin/Staff (日次・週次)
+- Navigate to Schedules → 日次 tab
+- Open Class Type filter, select "通常授業" → only regular classes show
+- Multi-select add "特別授業" → both types show
+- Switch to 週次 tab → selection persists
+- Reload page → selection persists (per-role)
+
+## Teacher/Student (Week/Month)
+- Open Week view → select class types and confirm filtering
+- Switch to Month → selection carries over; day cells reflect filter
+- Click a day → navigates to Week with selection intact
+
+## Persistence
+- Switch branches → selection remains (shared per-role)
+- Clear filter → all types shown (no selection = all)
+
+## Notes
+- Options load from `/api/class-types` (ordered)
+- Exact match filtering (no descendant inclusion)
+

--- a/specs/014-we-should-add/research.md
+++ b/specs/014-we-should-add/research.md
@@ -1,0 +1,41 @@
+# Research: Class Type Filters Across Schedule Views
+
+## Decisions
+- Persistence model: Per-role via localStorage; cross-view; across reloads; same across branches.
+  - Rationale: Matches existing filters’ persistence patterns; minimal overhead.
+  - Alternatives: URL params (shareable) rejected per spec; server-side profile rejected as scope creep.
+
+- Filter semantics: Exact match only; selecting a parent does not include descendants.
+  - Rationale: Clear, predictable filtering; avoids hidden hierarchy coupling.
+  - Alternatives: Include descendants or a toggle; deferred to future if needed.
+
+- Default “All”: No selection = all (no explicit “All” option).
+  - Rationale: Aligns with existing table filters and reduces UI noise.
+
+- Source of truth for options: Server API `GET /api/class-types` (ordered by `order`, then `name`).
+  - Rationale: Centralized, up-to-date list; avoids client drift.
+  - Alternatives: Faceted uniques from current view rejected (incomplete set).
+
+- Branch scoping: Same selection across all branches.
+  - Rationale: Simpler UX, consistent with other persisted filters.
+
+- Empty options behavior: Show the control disabled with an informative hint (e.g., "クラスタイプがありません").
+  - Rationale: Discoverability; hides less capability compared to removing control.
+
+## Accessibility & Localization (Non-blocking Assumptions)
+- Accessibility: Target keyboard operability and ARIA for combobox and chips. Aim for WCAG 2.1 AA.
+- Localization: Provide JA strings; keep text extractable for future EN.
+
+## Endpoints & Data
+- Existing: `GET /api/class-types` returns paginated class type list (server truth).
+- Proposed: Support `classTypeIds` (CSV or repeated) for teacher/student me endpoints to allow server-side filtering for multi-select.
+  - If not implemented immediately, fall back to client-side filtering on fetched results.
+
+## Risks
+- Multi-select server filtering may require API changes and pagination considerations in `teachers/students me` endpoints.
+- Client-side filtering on large result sets could impact performance; mitigate with pagination or server-side support.
+
+## Open Items (non-blocking)
+- Exact accessibility acceptance checklist.
+- Confirm localized copy for empty/zero-results states.
+

--- a/specs/014-we-should-add/spec.md
+++ b/specs/014-we-should-add/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Class Type Filters Across Schedule Views
+
+**Feature Branch**: `014-we-should-add`  
+**Created**: 2025-10-07  
+**Status**: Draft  
+**Input**: User description: "We should add a class type filter into `src/components/admin-schedule/DayCalendar/day-calendar-filters.tsx` for admin and staff users in both 日次 and 週次 view tabs. Teachers’ and students’ week class view table and monthly view should also support filtering by class types. Reference existing filter components and the searchable, selectable combobox filter. If possible, reference the シリーズ view’s table filter, which is multi-selectable and searchable, as the best implementation. Can we do that?"
+
+## Execution Flow (main)
+```
+1. Parse user description from Input
+   → If empty: ERROR "No feature description provided"
+2. Extract key concepts from description
+   → Identify: actors, actions, data, constraints
+3. For each unclear aspect:
+   → Mark with [NEEDS CLARIFICATION: specific question]
+4. Fill User Scenarios & Testing section
+   → If no clear user flow: ERROR "Cannot determine user scenarios"
+5. Generate Functional Requirements
+   → Each requirement must be testable
+   → Mark ambiguous requirements
+6. Identify Key Entities (if data involved)
+7. Run Review Checklist
+   → If any [NEEDS CLARIFICATION]: WARN "Spec has uncertainties"
+   → If implementation details found: ERROR "Remove tech details"
+8. Return: SUCCESS (spec ready for planning)
+```
+
+---
+
+## ⚡ Quick Guidelines
+- ✅ Focus on WHAT users need and WHY
+- ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
+- 👥 Written for business stakeholders, not developers
+
+### Section Requirements
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+When creating this spec from a user prompt:
+1. **Mark all ambiguities**: Use [NEEDS CLARIFICATION: specific question] for any assumption you'd need to make
+2. **Don't guess**: If the prompt doesn't specify something (e.g., "login system" without auth method), mark it
+3. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+4. **Common underspecified areas**:
+   - User types and permissions
+   - Data retention/deletion policies  
+   - Performance targets and scale
+   - Error handling behaviors
+   - Integration requirements
+   - Security/compliance needs
+
+---
+
+## User Scenarios & Testing (mandatory)
+
+### Primary User Story
+As an admin or staff member, I want to filter classes shown on both the Daily (日次) and Weekly (週次) schedule views by one or more Class Types (e.g., 通常授業, 特別授業) so that I can focus on relevant sessions. As a teacher or student, I want the Week table and Monthly calendar to support the same Class Type filtering so I can quickly find the classes that matter to me.
+
+### Acceptance Scenarios
+1. Given the admin Daily (日次) view with many classes, When the user opens the Class Type filter and selects "通常授業", Then only sessions of type "通常授業" are displayed.
+2. Given the admin Daily (日次) view, When the user multi-selects "通常授業" and "特別授業", Then sessions of either type are shown.
+3. Given the admin Weekly (週次) view, When the user applies a Class Type selection in Daily view and switches to Weekly, Then the same selection remains active across the two tabs and persists globally for that role.
+4. Given the admin Weekly (週次) view with no sessions matching the selected Class Types, When the filter is applied, Then the view shows a clear empty state (e.g., "該当する授業がありません").
+5. Given the teacher Week view table, When the teacher selects one or more Class Types via a searchable control, Then only matching sessions appear in the table.
+6. Given the student Week view table, When a Class Type filter is applied, Then the displayed sessions are limited to the selected types and the total count reflects the filtered set.
+7. Given the student Monthly view, When the user selects Class Types, Then day cells show only lessons of the chosen types; tapping a day navigates to Week view with the same filter carried over and persisted.
+8. Given any supported view with an active filter, When the user clears the filter, Then all Class Types are shown again (default state: no selection = all).
+9. Given the filter control, When the user types in the search box within the filter, Then matching Class Type options are narrowed in real time.
+10. Given any supported view with an active Class Type filter, When the user reloads the page or navigates away and returns, Then the prior selection persists (per-role, via local storage) and is reapplied.
+11. Given a user switches between school branches, When a Class Type selection exists, Then the same selection remains (not scoped per branch) to match existing filter behavior.
+
+### Edge Cases
+- No available Class Types: The filter control indicates no options [NEEDS CLARIFICATION: Should the filter be hidden or disabled when no types exist?].
+- Very large number of Class Types: The filter remains performant and searchable, and supports multi-select without excessive scroll.
+- Accessibility: The filter is fully keyboard-operable and screen-reader friendly [NEEDS CLARIFICATION: Specific accessibility criteria to meet, e.g., WCAG level].
+- Localization: All filter labels and empty states are localized (JA/EN as applicable) [NEEDS CLARIFICATION: Required locales].
+- Persistence: Selection persists globally per role across views and across sessions via local storage; not encoded in URL or shared links.
+
+## Clarifications
+
+### Session 2025-10-07
+
+- Q: How should Class Type filter selections persist across views and navigation? → A: Global per-role via local storage; cross-view; URL not required.
+- Q: When a parent Class Type is selected, should filtering include descendant types? → A: Exact match only (no descendants).
+- Q: What is the default “All” behavior when no Class Types are selected? → A: No selection means all types; no explicit “All” option.
+- Q: Where should Class Type options and display labels come from? → A: Server-provided list (API) matching classTypeName used in sessions.
+- Q: When users switch between branches, should the selection be the same or saved separately? → A: Same selection for all branches (align with existing filters).
+
+## Requirements (mandatory)
+
+### Functional Requirements
+- FR-001: Provide a Class Type filter in the admin/staff Daily (日次) schedule view.
+- FR-002: Provide a Class Type filter in the admin/staff Weekly (週次) schedule view.
+- FR-003: Provide a Class Type filter in the teacher Week view table.
+- FR-004: Provide a Class Type filter in the student Week view table.
+- FR-005: Provide a Class Type filter in the student Monthly view (and any Monthly view where students/teachers browse schedules).
+- FR-006: The filter MUST support multi-select of Class Types.
+- FR-007: The filter MUST be searchable to quickly find Class Types by name/label.
+- FR-008: When no Class Types are selected, the default state shows all Class Types [NEEDS CLARIFICATION: Confirm "no selection = all" vs explicit "All" option].
+- FR-008: When no Class Types are selected, the default state shows all Class Types (no explicit “All” option; no selection = all).
+- FR-009: The filter’s active state MUST be clearly visible and show the count or chips of selected Class Types.
+- FR-010: Clearing the filter MUST restore the full, unfiltered schedule.
+- FR-011: The filter behavior SHOULD be consistent across views and roles (labels, empty states, clear/reset behavior) and mirror the existing multi-select, searchable pattern used in the Series list filter.
+ - FR-012: The filtering MUST operate on the same Class Type dimension used by schedules (matches the `classTypeName` users see); options and labels come from a server-provided list (API).
+- FR-013: Active filter selection persists globally per role across views (日次↔週次, Week↔Month) and across sessions via local storage; URL parameters are not required.
+- FR-014: For teacher/student flows, the selection persists between Week and Month views, across navigation and reloads, scoped per role and stored locally.
+- FR-018: Selecting a Class Type filters by exact match only; selecting a parent type does not implicitly include descendant types.
+- FR-019: Persistence is not scoped per branch; the same per-role selection applies across all branches (following existing filter patterns).
+- FR-015: The filter MUST handle 0-results gracefully with a clear, localized empty state message.
+- FR-016: The control MUST meet basic accessibility: keyboard navigation, focus management, ARIA labels, and contrast guidelines [NEEDS CLARIFICATION: exact standard].
+- FR-017: The filter MUST not materially degrade schedule rendering performance at typical data sizes; interactions should remain responsive.
+
+### Key Entities (data-related)
+- Class Type
+  - What it represents: A categorical label for a class session (e.g., 通常授業, 特別授業).
+  - Key attributes: Identifier, display name (localized), optional color/legend mapping.
+  - Relationships: Associated with Class Sessions; used as a facet in schedule views.
+- Schedule View
+  - Variants: Daily (日次), Weekly (週次), Monthly (月次), and Week table views used by teachers/students.
+  - Behavior: Each view supports filtering by Class Type; filtered results update counts and lists/calendars.
+- User Role
+  - Roles: Admin, Staff, Teacher, Student.
+  - Access: All see a Class Type filter in their relevant schedule contexts; admin/staff specifically in 日次/週次 tabs.
+
+---
+
+## Review & Acceptance Checklist
+*GATE: Automated checks run during main() execution*
+
+### Content Quality
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+### Requirement Completeness
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous  
+- [ ] Success criteria are measurable
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+---
+
+## Execution Status
+*Updated by main() during processing*
+
+- [x] User description parsed
+- [x] Key concepts extracted
+- [x] Ambiguities marked
+- [x] User scenarios defined
+- [x] Requirements generated
+- [x] Entities identified
+- [ ] Review checklist passed
+
+---

--- a/specs/014-we-should-add/tasks.md
+++ b/specs/014-we-should-add/tasks.md
@@ -1,0 +1,154 @@
+# Tasks: Class Type Filters Across Schedule Views
+
+Feature dir: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add
+Plan: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/plan.md
+
+## Phase 3.1: Setup
+- [ ] T001 Ensure Vitest + RTL configured for Next.js (no new deps). Verify `bun test` runs with jsdom.
+  - Files: package.json, vitest.config.ts (if present)
+  - Note: Use Bun for scripts; do not add npm/yarn steps.
+
+- [ ] T002 [P] Create per-role persistence helper for Class Type selection
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/lib/class-type-filter-persistence.ts
+  - Contents: `getClassTypeSelection(role)`, `setClassTypeSelection(role, ids)`, key `filter:classTypes:{role}`; no-branch scoping.
+
+- [ ] T003 [P] Fetch options helper for Class Types (ordered by order then name)
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/lib/class-type-options.ts
+  - Contents: `fetchClassTypeOptions(): Promise<Array<{value:string,label:string}>>` using `/api/class-types`.
+
+## Phase 3.2: Tests First (TDD)
+Contract tests (1 per contract file) — must be written and fail before impl
+
+- [ ] T004 [P] Contract test: GET /api/class-types returns ordered items and pagination
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/contracts/__tests__/class-types.contract.test.ts
+  - Based on: contracts/class-types.yaml
+
+- [ ] T005 [P] Contract test: GET /api/teachers/me/class-sessions supports classTypeIds filter
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/contracts/__tests__/teachers-me-class-sessions.contract.test.ts
+  - Based on: contracts/teachers-me-class-sessions.yaml
+
+- [ ] T006 [P] Contract test: GET /api/students/me/class-sessions supports classTypeIds filter
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/contracts/__tests__/students-me-class-sessions.contract.test.ts
+  - Based on: contracts/students-me-class-sessions.yaml
+
+Integration tests (from user stories; UI-level where practical)
+
+- [ ] T007 Integration: Admin 日次 filter “通常授業” shows only regular sessions
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/integration-tests/admin-day-filter.test.tsx
+  - Target: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/admin-schedule/DayCalendar/day-calendar-filters.tsx
+
+- [ ] T008 Integration: Admin 日次 multi-select “通常授業”+“特別授業” shows union
+  - File: same as T007 (sequential in same file)
+
+- [ ] T009 [P] Integration: Admin 週次 retains selection from 日次 and shows filtered
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/integration-tests/admin-week-filter.test.tsx
+  - Target: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx
+
+- [ ] T010 [P] Integration: Teacher Week/Month respects selection and carries over Month→Week
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/integration-tests/teacher-week-month-filter.test.tsx
+  - Targets:
+    - /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/app/teacher/page.tsx
+    - /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/student-schedule/student-schedule-week-viewer.tsx
+    - /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/student-schedule/student-schedule-month-viewer.tsx
+
+- [ ] T011 [P] Integration: Student Week/Month respects selection; reload persists per-role; branch switch remains
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/integration-tests/student-week-month-filter.test.tsx
+  - Targets:
+    - /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/app/student/page.tsx
+    - /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/student-schedule/student-schedule-week-viewer.tsx
+    - /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/student-schedule/student-schedule-month-viewer.tsx
+
+## Phase 3.3: Core Implementation
+Admin filters
+
+- [ ] T012 Add Class Type multi-select to admin 日次 filters UI
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/admin-schedule/DayCalendar/day-calendar-filters.tsx
+  - Use: `Faceted` components for searchable multi-select; options via class-type-options.ts; persist via class-type-filter-persistence.ts
+  - Sequential with T013 (same file)
+
+- [ ] T013 Wire selected classTypeIds to DayFilters and queries/rendering
+  - Files: same as T012; and /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/hooks/useClassSessionQuery.ts (extend DayFilters and query params)
+
+Admin week
+
+- [ ] T014 Add Class Type filter UI to admin 週次 header (next to WeekSelector)
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx
+  - Use the same Faceted control and persistence
+
+- [ ] T015 Apply selected classTypeIds to week data queries (useMultipleWeeksClassSessions)
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/hooks/useClassSessionQuery.ts (append classTypeIds to params and/or client filter)
+
+Teacher and student views
+
+- [ ] T016 Add Class Type filter control to Teacher page toolbar and persist per-role
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/app/teacher/page.tsx
+  - Pass `classTypeIds` to `useTeacherClassSessionsDateRange`
+
+- [ ] T017 Update `useTeacherClassSessionsDateRange` to accept optional `classTypeIds` and pass to API
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/hooks/useClassSessionQuery.ts
+
+- [ ] T018 Add Class Type filter control to Student views (parent container) and persist per-role
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/app/student/page.tsx
+
+- [ ] T019 Update `useStudentClassSessionsDateRange` to accept optional `classTypeIds` and pass to API
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/hooks/useClassSessionQuery.ts
+
+## Phase 3.4: Integration (API support)
+
+- [ ] T020 Extend GET /api/teachers/me/class-sessions to support `classTypeIds` (CSV) exact-match IN filter
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/app/api/teachers/me/class-sessions/route.ts
+  - Back-compat: keep existing single `classTypeId` behavior
+
+- [ ] T021 Extend GET /api/students/me/class-sessions to support `classTypeIds` (CSV) exact-match IN filter
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/app/api/students/me/class-sessions/route.ts
+  - Back-compat: keep existing single `classTypeId` behavior
+
+## Phase 3.5: Polish
+
+- [ ] T022 [P] Debounce search inputs and memoize options to minimize re-renders
+  - Files: Faceted-based controls in admin/teacher/student UIs
+
+- [ ] T023 [P] Accessibility pass: keyboard operability, ARIA labels for combobox and chips
+  - Files: the new Faceted controls; ensure labels and aria attributes
+
+- [ ] T024 [P] i18n: Localize labels and empty/zero-result messages (JA-first)
+
+- [ ] T025 Validation: Follow quickstart to verify reload and branch-switch persistence
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/specs/014-we-should-add/quickstart.md
+
+## Phase 3.6: Entity Types (from data-model) [P]
+
+- [ ] T027 [P] Define TS interfaces for ClassType and ClassTypeOption
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/types/class-type.ts
+  - Contents: `export interface ClassTypeDTO { classTypeId; name; parentId; order; color }` and `export type ClassTypeOption = { value; label }`
+
+- [ ] T028 [P] Define TS types for FilterState and ViewVariant
+  - File: /Users/muhammadnurislomtukhtamishhoji-zoda/Development/schedule-website/src/types/class-type-filter.ts
+  - Contents: `export type ClassTypeFilterState = { selectedClassTypeIds: string[]; updatedAt: string }`; `export type ViewVariant = 'DAY'|'WEEK'|'MONTH'`
+
+- [ ] T026 Cleanup: Remove debug logs; run `bun lint` and `bun test`
+
+## Dependencies
+- T004–T006 (contract tests) before T020–T021 (endpoint support)
+- T007–T011 (integration tests) before T012–T019 (UI + hooks)
+- T012 blocks T013; T014 blocks T015; T016 blocks T017; T018 blocks T019
+- API extensions (T020–T021) can proceed in parallel [P] if files are separate
+- Polish (T022–T026) after core and integration
+
+## Parallel Execution Examples
+Launch contract tests together:
+Task: "T004 Contract test /api/class-types in specs/014-we-should-add/contracts/__tests__/class-types.contract.test.ts"
+Task: "T005 Contract test /api/teachers/me/class-sessions in specs/014-we-should-add/contracts/__tests__/teachers-me-class-sessions.contract.test.ts"
+Task: "T006 Contract test /api/students/me/class-sessions in specs/014-we-should-add/contracts/__tests__/students-me-class-sessions.contract.test.ts"
+
+Launch UI integration tests together after setup:
+Task: "T007 Admin 日次 filter test"
+Task: "T009 Admin 週次 filter test"
+Task: "T010 Teacher Week/Month filter test"
+Task: "T011 Student Week/Month filter test"
+
+## Notes
+- [P] tasks = different files, no dependencies
+- Tests must fail before implementation (TDD)
+- Use Bun for scripts (e.g., `bun test`, `bun lint`)
+- Place tests near spec (under specs/014-we-should-add) to keep scope contained

--- a/src/app/api/class-types/route.ts
+++ b/src/app/api/class-types/route.ts
@@ -71,7 +71,7 @@ const validateHierarchy = async (
 
 // GET - List class types with pagination and filters
 export const GET = withRole(
-  ["ADMIN", "STAFF", "TEACHER"],
+  ["ADMIN", "STAFF", "TEACHER", "STUDENT"],
   async (request: NextRequest, session) => {
     // Parse query parameters
     const url = new URL(request.url);

--- a/src/app/api/students/me/class-sessions/route.ts
+++ b/src/app/api/students/me/class-sessions/route.ts
@@ -67,9 +67,11 @@ export const GET = withRole(
       // Parse query parameters
       const url = new URL(request.url);
       const params = Object.fromEntries(url.searchParams.entries());
+      const classTypeIdsCsv = url.searchParams.get('classTypeIds');
 
       // Remove studentId from params since we'll use session data
-      const { studentId: _, ...filteredParams } = params;
+      // Remove unsupported params before schema validation
+      const { studentId: _, classTypeIds: _ignoredClassTypeIds, ...filteredParams } = params;
 
       // Validate and parse filter parameters
       const result = classSessionFilterSchema.safeParse(filteredParams);
@@ -121,6 +123,12 @@ export const GET = withRole(
 
       if (classTypeId) {
         where.classTypeId = classTypeId;
+      }
+      if (classTypeIdsCsv) {
+        const list = classTypeIdsCsv.split(',').map(s => s.trim()).filter(Boolean);
+        if (list.length > 0) {
+          where.classTypeId = { in: list };
+        }
       }
 
       if (boothId) {

--- a/src/app/api/teachers/me/class-sessions/route.ts
+++ b/src/app/api/teachers/me/class-sessions/route.ts
@@ -67,9 +67,11 @@ export const GET = withRole(
       // Parse query parameters
       const url = new URL(request.url);
       const params = Object.fromEntries(url.searchParams.entries());
+      const classTypeIdsCsv = url.searchParams.get('classTypeIds');
 
       // Remove teacherId from params since we'll use session data
-      const { teacherId: _, ...filteredParams } = params;
+      // Remove unsupported params before schema validation
+      const { teacherId: _, classTypeIds: _ignoredClassTypeIds, ...filteredParams } = params;
 
       // Validate and parse filter parameters
       const result = classSessionFilterSchema.safeParse(filteredParams);
@@ -121,6 +123,12 @@ export const GET = withRole(
 
       if (classTypeId) {
         where.classTypeId = classTypeId;
+      }
+      if (classTypeIdsCsv) {
+        const list = classTypeIdsCsv.split(',').map(s => s.trim()).filter(Boolean);
+        if (list.length > 0) {
+          where.classTypeId = { in: list };
+        }
       }
 
       if (boothId) {

--- a/src/app/student/page.tsx
+++ b/src/app/student/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import { SPECIAL_CLASS_COLOR_CLASSES } from "@/lib/special-class-constants";
+import { X } from "lucide-react";
 import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from "@/components/ui/faceted";
 import { fetchClassTypeOptions } from "@/lib/class-type-options";
 import type { ClassTypeOption } from "@/types/class-type";
@@ -164,7 +165,7 @@ export default function StudentPage() {
                 currentDate={currentDate}
               />
             </div>
-            <div className="ml-2">
+            <div className="ml-2 flex items-center gap-1">
               <Faceted multiple value={classTypeIds} onValueChange={handleClassTypesChange}>
                 <FacetedTrigger
                   aria-label="クラスタイプフィルター"
@@ -188,6 +189,18 @@ export default function StudentPage() {
                   </FacetedList>
                 </FacetedContent>
               </Faceted>
+              {classTypeIds && classTypeIds.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleClassTypesChange([])}
+                  className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="クラスタイプをクリア"
+                  title="クリア"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
             </div>
           </div>
 

--- a/src/app/teacher/page.tsx
+++ b/src/app/teacher/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import { SPECIAL_CLASS_COLOR_CLASSES } from "@/lib/special-class-constants";
+import { X } from "lucide-react";
 import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from "@/components/ui/faceted";
 import { fetchClassTypeOptions } from "@/lib/class-type-options";
 import type { ClassTypeOption } from "@/types/class-type";
@@ -165,7 +166,7 @@ export default function TeacherPage() {
                 currentDate={currentDate}
               />
             </div>
-            <div className="ml-2">
+            <div className="ml-2 flex items-center gap-1">
               <Faceted multiple value={classTypeIds} onValueChange={handleClassTypesChange}>
                 <FacetedTrigger
                   aria-label="クラスタイプフィルター"
@@ -189,6 +190,18 @@ export default function TeacherPage() {
                   </FacetedList>
                 </FacetedContent>
               </Faceted>
+              {classTypeIds && classTypeIds.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleClassTypesChange([])}
+                  className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="クラスタイプをクリア"
+                  title="クリア"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
             </div>
           </div>
 

--- a/src/app/teacher/page.tsx
+++ b/src/app/teacher/page.tsx
@@ -13,8 +13,13 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SPECIAL_CLASS_COLOR_CLASSES } from "@/lib/special-class-constants";
+import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from "@/components/ui/faceted";
+import { fetchClassTypeOptions } from "@/lib/class-type-options";
+import type { ClassTypeOption } from "@/types/class-type";
+import { useSession } from "next-auth/react";
+import { getClassTypeSelection, setClassTypeSelection } from "@/lib/class-type-filter-persistence";
 
 const daysOfWeek = ["月", "火", "水", "木", "金", "土", "日"];
 const getColor = (subjecType: "通常授業" | "特別授業") => {
@@ -40,6 +45,37 @@ const getColor = (subjecType: "通常授業" | "特別授業") => {
 export default function TeacherPage() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [viewType, setViewType] = useState<"WEEK" | "MONTH">("WEEK");
+  const { data: session } = useSession();
+  const role = session?.user?.role;
+  const [classTypeOptions, setClassTypeOptions] = useState<ClassTypeOption[]>([]);
+  const [classTypeIds, setClassTypeIds] = useState<string[] | undefined>(undefined);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const opts = await fetchClassTypeOptions();
+        if (mounted) setClassTypeOptions(opts);
+      } catch {
+        if (mounted) setClassTypeOptions([]);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // init from persistence
+  useEffect(() => {
+    if (!classTypeIds || classTypeIds.length === 0) {
+      const saved = getClassTypeSelection(role);
+      if (saved && saved.length > 0) setClassTypeIds(saved);
+    }
+  }, [role]);
+
+  const handleClassTypesChange = (ids: string[] | undefined) => {
+    const next = Array.isArray(ids) ? ids : [];
+    setClassTypeIds(next.length ? next : undefined);
+    setClassTypeSelection(role, next);
+  };
 
   const { startDate, endDate } = useMemo(() => {
     if (viewType === "WEEK") {
@@ -64,6 +100,7 @@ export default function TeacherPage() {
   const { data, error, isPending } = useTeacherClassSessionsDateRange({
     startDate,
     endDate,
+    classTypeIds,
   });
 
   if (isPending) {
@@ -127,6 +164,31 @@ export default function TeacherPage() {
                 setCurrentDate={setCurrentDate}
                 currentDate={currentDate}
               />
+            </div>
+            <div className="ml-2">
+              <Faceted multiple value={classTypeIds} onValueChange={handleClassTypesChange}>
+                <FacetedTrigger
+                  aria-label="クラスタイプフィルター"
+                  className="h-8 w-[220px] max-w-[240px] border border-input rounded-md px-2 bg-background text-foreground hover:bg-accent hover:text-accent-foreground text-sm flex items-center justify-between whitespace-nowrap overflow-hidden"
+                >
+                  <span className="truncate">
+                    {`クラスタイプ${classTypeIds?.length ? `（${classTypeIds.length}）` : ""}`}
+                  </span>
+                </FacetedTrigger>
+                <FacetedContent className="w-[240px]">
+                  <FacetedInput placeholder="クラスタイプを検索..." />
+                  <FacetedList>
+                    <FacetedEmpty>候補がありません</FacetedEmpty>
+                    <FacetedGroup heading="クラスタイプ">
+                      {classTypeOptions.map((opt) => (
+                        <FacetedItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </FacetedItem>
+                      ))}
+                    </FacetedGroup>
+                  </FacetedList>
+                </FacetedContent>
+              </Faceted>
             </div>
           </div>
 

--- a/src/components/admin-schedule/DayCalendar/admin-calendar-day.tsx
+++ b/src/components/admin-schedule/DayCalendar/admin-calendar-day.tsx
@@ -288,14 +288,21 @@ export default function AdminCalendarDay({ selectedBranchId }: AdminCalendarDayP
       const dateStr = selectedDatesStrings[index];
 
       if (query.data?.data && Array.isArray(query.data.data)) {
-        sessionsByDate[dateStr] = query.data.data;
+        let arr = query.data.data;
+        const filter = enhancedDayFilters[dateStr];
+        const ids = filter?.classTypeIds || [];
+        if (ids.length > 0) {
+          // Exact match only; exclude sessions with null/undefined classTypeId
+          arr = arr.filter((s) => s.classTypeId ? ids.includes(s.classTypeId) : false);
+        }
+        sessionsByDate[dateStr] = arr;
       } else {
         sessionsByDate[dateStr] = [];
       }
     });
 
     return sessionsByDate;
-  }, [classSessionQueries, selectedDatesStrings]);
+  }, [classSessionQueries, selectedDatesStrings, enhancedDayFilters]);
 
   const isLoading = useMemo(() => {
     return classSessionQueries.some(query => query.isLoading || query.isFetching);

--- a/src/components/admin-schedule/DayCalendar/day-calendar-filters.tsx
+++ b/src/components/admin-schedule/DayCalendar/day-calendar-filters.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { SearchableSelect, SearchableSelectItem } from '../searchable-select';
 import { useSubjects } from '@/hooks/useSubjectQuery';
@@ -8,6 +8,11 @@ import { CompatibilityComboboxItem, getCompatibilityPriority, renderCompatibilit
 import { useDebounce } from '@/hooks/use-debounce';
 import { DayFilters } from '@/hooks/useClassSessionQuery';
 import { X } from 'lucide-react';
+import { useSession } from 'next-auth/react';
+import { fetchClassTypeOptions } from '@/lib/class-type-options';
+import { getClassTypeSelection, setClassTypeSelection } from '@/lib/class-type-filter-persistence';
+import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from '@/components/ui/faceted';
+import type { ClassTypeOption } from '@/types/class-type';
 
 interface DayCalendarFiltersProps {
   filters: DayFilters;
@@ -20,6 +25,8 @@ export const DayCalendarFilters: React.FC<DayCalendarFiltersProps> = ({
   onFiltersChange,
   dateKey
 }) => {
+  const { data: session } = useSession();
+  const role = session?.user?.role;
   const { data: subjectsResponse, isLoading: isLoadingSubjects } = useSubjects({
     limit: 100
   });
@@ -30,6 +37,26 @@ export const DayCalendarFilters: React.FC<DayCalendarFiltersProps> = ({
     value: subject.subjectId,
     label: subject.name,
   }));
+
+  // Class Type options (server-provided)
+  const [classTypeOptions, setClassTypeOptions] = useState<ClassTypeOption[]>([]);
+  const [classTypeLoading, setClassTypeLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setClassTypeLoading(true);
+      try {
+        const opts = await fetchClassTypeOptions();
+        if (mounted) setClassTypeOptions(opts);
+      } finally {
+        if (mounted) setClassTypeLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   // Smart matching + searchable combobox for teacher/student (same as admin-calendar-day)
   const [teacherSearch, setTeacherSearch] = useState<string>('');
@@ -192,13 +219,74 @@ export const DayCalendarFilters: React.FC<DayCalendarFiltersProps> = ({
 
   const clearAllFilters = () => {
     onFiltersChange({});
+    // Also clear persisted class type selection
+    setClassTypeSelection(role, []);
   };
 
-  const hasActiveFilters = Boolean(filters.subjectId || filters.teacherId || filters.studentId);
+  // Initialize class type selection from persistence on first render if empty
+  useEffect(() => {
+    if (!filters.classTypeIds || filters.classTypeIds.length === 0) {
+      const saved = getClassTypeSelection(role);
+      if (saved && saved.length > 0) {
+        onFiltersChange({ ...filters, classTypeIds: saved });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [role]);
+
+  const handleClassTypesChange = (ids: string[] | undefined) => {
+    const next = Array.isArray(ids) ? ids : [];
+    onFiltersChange({ ...filters, classTypeIds: next.length ? next : undefined });
+    setClassTypeSelection(role, next);
+  };
+
+  const hasActiveFilters = Boolean(
+    filters.subjectId ||
+    filters.teacherId ||
+    filters.studentId ||
+    (filters.classTypeIds && filters.classTypeIds.length > 0)
+  );
 
   return (
     <div className="flex items-center gap-2">
       <div className="flex items-center gap-2 flex-wrap">
+        {/* Class Type multi-select (searchable, multi) */}
+        <div className="flex items-center gap-1">
+          <Faceted multiple value={filters.classTypeIds} onValueChange={handleClassTypesChange}>
+            <FacetedTrigger
+              aria-label="クラスタイプフィルター"
+              className="h-8 w-[220px] max-w-[240px] border border-input rounded-md px-2 bg-background text-foreground hover:bg-accent hover:text-accent-foreground text-sm flex items-center justify-between whitespace-nowrap overflow-hidden"
+            >
+              <span className="truncate">
+                {`クラスタイプ${filters.classTypeIds?.length ? `（${filters.classTypeIds.length}）` : ""}`}
+              </span>
+            </FacetedTrigger>
+            <FacetedContent className="w-[240px]">
+              <FacetedInput placeholder="クラスタイプを検索..." />
+              <FacetedList>
+                <FacetedEmpty>候補がありません</FacetedEmpty>
+                <FacetedGroup heading="クラスタイプ">
+                  {classTypeOptions.map((opt) => (
+                    <FacetedItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </FacetedItem>
+                  ))}
+                </FacetedGroup>
+              </FacetedList>
+            </FacetedContent>
+          </Faceted>
+          {filters.classTypeIds && filters.classTypeIds.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleClassTypesChange([])}
+              className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+              disabled={classTypeLoading}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
         <div className="flex items-center gap-1">
           <SearchableSelect
             value={filters.subjectId || ''}
@@ -289,12 +377,14 @@ export const DayCalendarFilters: React.FC<DayCalendarFiltersProps> = ({
 
       {hasActiveFilters && (
         <Button
-          variant="outline"
+          variant="ghost"
           size="sm"
           onClick={clearAllFilters}
-          className="h-8 text-xs whitespace-nowrap"
+          className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+          aria-label="すべてクリア"
+          title="すべてクリア"
         >
-          すべてクリア
+          <X className="h-4 w-4" />
         </Button>
       )}
     </div>

--- a/src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx
+++ b/src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx
@@ -26,6 +26,8 @@ import { fetchClassTypeOptions } from "@/lib/class-type-options";
 import { getClassTypeSelection, setClassTypeSelection } from "@/lib/class-type-filter-persistence";
 import type { ClassTypeOption } from "@/types/class-type";
 import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from "@/components/ui/faceted";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
 
 const SELECTED_WEEKS_KEY = "admin_calendar_selected_weeks";
 const BASE_WEEK_KEY = "admin_calendar_base_week";
@@ -439,6 +441,18 @@ const AdminCalendarWeek: React.FC<AdminCalendarWeekProps> = ({
                 </FacetedList>
               </FacetedContent>
             </Faceted>
+            {filters.classTypeIds && filters.classTypeIds.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleClassTypesChange([])}
+                className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+                aria-label="クラスタイプをクリア"
+                title="クリア"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/data-table/data-table-filter-menu.tsx
+++ b/src/components/data-table/data-table-filter-menu.tsx
@@ -740,7 +740,7 @@ function onFilterInputRender<TData>({
                   </div>
                   <span className="truncate">
                     {selectedOptions.length > 1
-                      ? `${selectedOptions.length} selected`
+                      ? `${selectedOptions.length} 選択済`
                       : selectedOptions[0]?.label}
                   </span>
                 </>

--- a/src/lib/class-type-filter-persistence.ts
+++ b/src/lib/class-type-filter-persistence.ts
@@ -1,0 +1,39 @@
+import { ClassTypeFilterState } from "@/types/class-type-filter";
+
+const KEY_PREFIX = "filter:classTypes:";
+
+export function getClassTypeSelection(role: string | undefined): string[] {
+  if (typeof window === "undefined") return [];
+  const k = KEY_PREFIX + (role || "UNKNOWN");
+  try {
+    const raw = localStorage.getItem(k);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as ClassTypeFilterState;
+    if (Array.isArray(parsed?.selectedClassTypeIds)) return parsed.selectedClassTypeIds;
+  } catch {
+    // ignore
+  }
+  return [];
+}
+
+export function setClassTypeSelection(role: string | undefined, ids: string[]): void {
+  if (typeof window === "undefined") return;
+  const k = KEY_PREFIX + (role || "UNKNOWN");
+  const state: ClassTypeFilterState = {
+    selectedClassTypeIds: Array.from(new Set(ids.filter(Boolean))),
+    updatedAt: new Date().toISOString(),
+  };
+  try {
+    localStorage.setItem(k, JSON.stringify(state));
+    // Notify other parts of the app (including other mounted tabs/views)
+    if (typeof BroadcastChannel !== 'undefined') {
+      try {
+        const ch = new BroadcastChannel('class-type-filter');
+        ch.postMessage({ type: 'classTypeSelectionChanged', role: role || 'UNKNOWN', ids: state.selectedClassTypeIds });
+        ch.close();
+      } catch {}
+    }
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/class-type-options.ts
+++ b/src/lib/class-type-options.ts
@@ -1,0 +1,15 @@
+import { fetcher } from "@/lib/fetcher";
+import { ClassTypeDTO, ClassTypeOption } from "@/types/class-type";
+
+type ClassTypesResponse = {
+  data: ClassTypeDTO[];
+  pagination?: { total: number; page: number; limit: number; pages: number };
+};
+
+export async function fetchClassTypeOptions(): Promise<ClassTypeOption[]> {
+  const params = new URLSearchParams({ page: "1", limit: "200", sortBy: "order", sortOrder: "asc", includeChildren: "false" });
+  const res = await fetcher<ClassTypesResponse>(`/api/class-types?${params.toString()}`);
+  // Preserve server ordering (order field, then name) — do not resort here
+  const arr = (res.data || []).map((ct) => ({ value: ct.classTypeId, label: ct.name }));
+  return arr;
+}

--- a/src/types/class-type-filter.ts
+++ b/src/types/class-type-filter.ts
@@ -1,0 +1,7 @@
+export type ClassTypeFilterState = {
+  selectedClassTypeIds: string[];
+  updatedAt: string; // ISO timestamp
+};
+
+export type ViewVariant = 'DAY' | 'WEEK' | 'MONTH';
+

--- a/src/types/class-type.ts
+++ b/src/types/class-type.ts
@@ -1,0 +1,10 @@
+export interface ClassTypeDTO {
+  classTypeId: string;
+  name: string;
+  parentId: string | null;
+  order: number | null;
+  color: string | null;
+}
+
+export type ClassTypeOption = { value: string; label: string };
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
     reporters: ["default"],
     setupFiles: ["./vitest.setup.ts"],
   },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
   css: {
     // Prevent Vite from loading the project's PostCSS config during tests
     postcss: {


### PR DESCRIPTION
This PR implements multi-select, searchable Class Type filters across schedule views and aligns behavior with the spec (014-we-should-add).

Key changes
- Admin/Staff
  - 日次 (Day) + 週次 (Week): add Class Type faceted filter (multi-select + searchable)
  - Per‑role persistence via localStorage; cross‑view sync using BroadcastChannel + storage event
  - Admin views filter client‑side (no unsupported params sent to /api/class-sessions)
- Teacher/Student
  - Week + Month: add same Class Type filter
  - Teacher/Student “me” endpoints now accept `classTypeIds` (CSV) and apply exact‑match IN filter
- Class Types source of truth & ordering
  - Options load from `/api/class-types`; preserve admin-defined order (order then name)
  - Allow STUDENT to fetch `/api/class-types` to populate filter in student view
- Styling & UX
  - Consistent filter trigger styling (h-8, border-input, rounded, compact width)
  - No layout shifts with many selections; trigger shows count (e.g., “クラスタイプ（n）”)
  - Icon-only clear buttons for per-filter and clear-all (compact, accessible)
- Fixes
  - Remove unsupported `classTypeIds` from `/api/class-sessions` requests (avoids 400s)
  - Week tab syncs with Day selection when both are mounted (Radix TabsContent) via BroadcastChannel
  - Student/Teacher fetches resilient to 403s; preserve server ordering; avoid resorting
- Tests
  - Contract tests for `/api/class-types`, `/api/teachers/me/class-sessions`, `/api/students/me/class-sessions`
  - Integration tests for Teacher/Student filter propagation
  - Vitest JSX config adjusted (automatic) to fix jsdom React issues

Paths of interest
- Filters/UI: `src/components/admin-schedule/DayCalendar/day-calendar-filters.tsx`, `src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx`, `src/app/teacher/page.tsx`, `src/app/student/page.tsx`
- Hooks: `src/hooks/useClassSessionQuery.ts`
- API: `src/app/api/teachers/me/class-sessions/route.ts`, `src/app/api/students/me/class-sessions/route.ts`, `src/app/api/class-types/route.ts`
- Persistence & options: `src/lib/class-type-filter-persistence.ts`, `src/lib/class-type-options.ts`
- Types: `src/types/class-type.ts`, `src/types/class-type-filter.ts`

Spec: specs/014-we-should-add/spec.md
Plan/Artifacts: specs/014-we-should-add/{plan.md,research.md,data-model.md,contracts/,quickstart.md,tasks.md}

Notes
- No DB migrations introduced
- Admin Day/Week keep client‑side filtering to avoid changing the general `/api/class-sessions` schema. Teacher/Student endpoints filter server‑side.
