### PR TITLE
feat(schedule): class type filters across schedule views with per‑role persistence, API support, and styling

### DIFF
--- a/src/app/student/page.tsx
+++ b/src/app/student/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import { SPECIAL_CLASS_COLOR_CLASSES } from "@/lib/special-class-constants";
+import { X } from "lucide-react";
 import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from "@/components/ui/faceted";
 import { fetchClassTypeOptions } from "@/lib/class-type-options";
 import type { ClassTypeOption } from "@/types/class-type";
@@ -164,7 +165,7 @@ export default function StudentPage() {
                 currentDate={currentDate}
               />
             </div>
-            <div className="ml-2">
+            <div className="ml-2 flex items-center gap-1">
               <Faceted multiple value={classTypeIds} onValueChange={handleClassTypesChange}>
                 <FacetedTrigger
                   aria-label="クラスタイプフィルター"
@@ -188,6 +189,18 @@ export default function StudentPage() {
                   </FacetedList>
                 </FacetedContent>
               </Faceted>
+              {classTypeIds && classTypeIds.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleClassTypesChange([])}
+                  className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="クラスタイプをクリア"
+                  title="クリア"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
             </div>
           </div>
 

--- a/src/app/teacher/page.tsx
+++ b/src/app/teacher/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "date-fns";
 import { useEffect, useMemo, useState } from "react";
 import { SPECIAL_CLASS_COLOR_CLASSES } from "@/lib/special-class-constants";
+import { X } from "lucide-react";
 import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from "@/components/ui/faceted";
 import { fetchClassTypeOptions } from "@/lib/class-type-options";
 import type { ClassTypeOption } from "@/types/class-type";
@@ -165,7 +166,7 @@ export default function TeacherPage() {
                 currentDate={currentDate}
               />
             </div>
-            <div className="ml-2">
+            <div className="ml-2 flex items-center gap-1">
               <Faceted multiple value={classTypeIds} onValueChange={handleClassTypesChange}>
                 <FacetedTrigger
                   aria-label="クラスタイプフィルター"
@@ -189,6 +190,18 @@ export default function TeacherPage() {
                   </FacetedList>
                 </FacetedContent>
               </Faceted>
+              {classTypeIds && classTypeIds.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleClassTypesChange([])}
+                  className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="クラスタイプをクリア"
+                  title="クリア"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
             </div>
           </div>
 

--- a/src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx
+++ b/src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx
@@ -26,6 +26,8 @@ import { fetchClassTypeOptions } from "@/lib/class-type-options";
 import { getClassTypeSelection, setClassTypeSelection } from "@/lib/class-type-filter-persistence";
 import type { ClassTypeOption } from "@/types/class-type";
 import { Faceted, FacetedBadgeList, FacetedContent, FacetedEmpty, FacetedGroup, FacetedInput, FacetedItem, FacetedList, FacetedTrigger } from "@/components/ui/faceted";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
 
 const SELECTED_WEEKS_KEY = "admin_calendar_selected_weeks";
 const BASE_WEEK_KEY = "admin_calendar_base_week";
@@ -439,6 +441,18 @@ const AdminCalendarWeek: React.FC<AdminCalendarWeekProps> = ({
                 </FacetedList>
               </FacetedContent>
             </Faceted>
+            {filters.classTypeIds && filters.classTypeIds.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleClassTypesChange([])}
+                className="h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive"
+                aria-label="クラスタイプをクリア"
+                title="クリア"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR re-introduces the class type filters from a fresh branch based on main, addressing previous branch cleanup.

Summary
- Admin/Staff: 日次 + 週次 class type filters (multi-select + searchable), per-role persistence, cross-view sync
- Teacher/Student: Week + Month filters; teachers/students endpoints accept `classTypeIds` (CSV) and apply exact-match IN filters
- Class types source/ordering: load from `/api/class-types`, preserve admin order; allow STUDENT role to fetch options
- Admin views: do not send unsupported params to `/api/class-sessions`; filter client-side
- Styling: compact, consistent triggers; icon-only clear buttons; fixed sizing to avoid layout shifts
- Tests: contract + integration tests; Vitest JSX config updated

Key files
- Filters/UI: `src/components/admin-schedule/DayCalendar/day-calendar-filters.tsx`, `src/components/admin-schedule/WeekCalendar/admin-calendar-week.tsx`, `src/app/teacher/page.tsx`, `src/app/student/page.tsx`
- Hooks: `src/hooks/useClassSessionQuery.ts`
- API: `src/app/api/teachers/me/class-sessions/route.ts`, `src/app/api/students/me/class-sessions/route.ts`, `src/app/api/class-types/route.ts`
- Utils: `src/lib/class-type-filter-persistence.ts`, `src/lib/class-type-options.ts`

Closes: supersedes prior PR for branch 014-we-should-add.
